### PR TITLE
Updates metric names to exclude the origin from the name.

### DIFF
--- a/metrics/_dea_logging_agent.html.md.erb
+++ b/metrics/_dea_logging_agent.html.md.erb
@@ -1,13 +1,15 @@
- Metric Name                                          | Description
-------------------------------------------------------|--------------------------------------------------------------------------
- dea\_logging\_agent.memoryStats.lastGCPauseTimeNS      | Duration of the last Garbage Collector pause in nanoseconds
- dea\_logging\_agent.memoryStats.numBytesAllocated      | Instantaneous count of bytes allocated and still in use
- dea\_logging\_agent.memoryStats.numBytesAllocatedHeap  | Instantaneous count of bytes allocated on the main heap and still in use
- dea\_logging\_agent.memoryStats.numBytesAllocatedStack | Instantaneous count of bytes used by the stack allocator
- dea\_logging\_agent.memoryStats.numFrees               | Lifetime number of memory deallocations
- dea\_logging\_agent.memoryStats.numMallocs             | Lifetime number of memory allocations
- dea\_logging\_agent.numCPUS                            | Number of CPUs on the machine
- dea\_logging\_agent.numGoRoutines                      | Instantaneous number of active Goroutines in the Doppler process
- dea\_logging\_agent.totalApps                          | The number of applications which the DEA logging agent is hooked onto
+Default Origin Name: dea_logging_agent
+
+Metric Name                         | Description
+------------------------------------|--------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS      | Duration of the last Garbage Collector pause in nanoseconds
+ memoryStats.numBytesAllocated      | Instantaneous count of bytes allocated and still in use
+ memoryStats.numBytesAllocatedHeap  | Instantaneous count of bytes allocated on the main heap and still in use
+ memoryStats.numBytesAllocatedStack | Instantaneous count of bytes used by the stack allocator
+ memoryStats.numFrees               | Lifetime number of memory deallocations
+ memoryStats.numMallocs             | Lifetime number of memory allocations
+ numCPUS                            | Number of CPUs on the machine
+ numGoRoutines                      | Instantaneous number of active Goroutines in the Doppler process
+ totalApps                          | The number of applications which the DEA logging agent is hooked onto
 
 [Top](#metrics-by-component)

--- a/metrics/_dea_logging_agent.html.md.erb
+++ b/metrics/_dea_logging_agent.html.md.erb
@@ -1,4 +1,4 @@
-Default Origin Name: dea_logging_agent
+Default Origin Name: dea\_logging\_agent
 
 Metric Name                         | Description
 ------------------------------------|--------------------------------------------------------------------------
@@ -12,4 +12,4 @@ Metric Name                         | Description
  numGoRoutines                      | Instantaneous number of active Goroutines in the Doppler process
  totalApps                          | The number of applications which the DEA logging agent is hooked onto
 
-[Top](#metrics-by-component)
+[Top](#top)

--- a/metrics/_doppler.html.md.erb
+++ b/metrics/_doppler.html.md.erb
@@ -49,4 +49,4 @@ Metric Name                                                 | Description
  signatureVerifier.validSignatures                          | Lifetime number of messages received with valid signatures
  Uptime							    | Uptime for the Doppler's process
 
-[Top](#metrics-by-component)
+[Top](#top)

--- a/metrics/_doppler.html.md.erb
+++ b/metrics/_doppler.html.md.erb
@@ -29,7 +29,7 @@ Metric Name                                                 | Description
  messageRouter.numberOfSyslogSinks                          | Instantaneous number of syslog sinks known to the SinkManager
  messageRouter.numberOfWebsocketSinks                       | Instantaneous number of websocket sinks known to the SinkManager
  messageRouter.totalDroppedMessages                         | Lifetime number of messages dropped inside Doppler for various reasons (downstream consumer can't keep up internal object wasn't ready for message, etc.)
- sentMessagesFirehose.<SUBSCRIPTION_ID>                     | Number of sent messages through the firehose per subscription id
+ sentMessagesFirehose.\<SUBSCRIPTION\_ID\>                     | Number of sent messages through the firehose per subscription id
  udpListener.receivedByteCount				    | Lifetime number of bytes received by Doppler's UDP Listener
  udpListener.receivedMessageCount			    | Lifetime number of messages received by Doppler's UDP Listener
  udpListener.receivedErrorCount				    | Lifetime number of errors encountered by Doppler's UDP Listener while reading from the connection

--- a/metrics/_doppler.html.md.erb
+++ b/metrics/_doppler.html.md.erb
@@ -1,48 +1,52 @@
-Metric Name                                                              | Description
---------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------
- DopplerServer.dropsondeListener.currentBufferCount                       | DEPRECATED
- DopplerServer.dropsondeListener.receivedByteCount                        | DEPRECATED in favor of DopplerServer.udpListener.receivedByteCount
- DopplerServer.dropsondeListener.receivedMessageCount                     | DEPRECATED in favor of DopplerServer.udpListener.receivedMessageCount
- DopplerServer.dropsondeUnmarshaller.containerMetricReceived              | Lifetime number of ContainerMetric messages unmarshalled
- DopplerServer.dropsondeUnmarshaller.counterEventReceived                 | Lifetime number of CounterEvent messages unmarshalled
- DopplerServer.dropsondeUnmarshaller.errorReceived                        | Lifetime number of Error messages unmarshalled
- DopplerServer.dropsondeUnmarshaller.heartbeatReceived                    | DEPRECATED
- DopplerServer.dropsondeUnmarshaller.httpStartReceived                    | Lifetime number of HttpStart messages unmarshalled
- DopplerServer.dropsondeUnmarshaller.httpStartStopReceived                | Lifetime number of HttpStartStop messages unmarshalled
- DopplerServer.dropsondeUnmarshaller.httpStopReceived                     | Lifetime number of HttpStop messages unmarshalled
- DopplerServer.dropsondeUnmarshaller.logMessageTotal                      | Lifetime number of LogMessage messages unmarshalled
- DopplerServer.dropsondeUnmarshaller.unmarshalErrors                      | Lifetime number of errors when unmarshalling messages
- DopplerServer.dropsondeUnmarshaller.valueMetricReceived                  | Lifetime number of ValueMetric messages unmarshalled
- DopplerServer.httpServer.receivedMessages                                | Number of messages received by Doppler's internal MessageRouter
- DopplerServer.memoryStats.lastGCPauseTimeNS                              | Duration of the last Garbage Collector pause in nanoseconds
- DopplerServer.memoryStats.numBytesAllocated                              | Instantaneous count of bytes allocated and still in use
- DopplerServer.memoryStats.numBytesAllocatedHeap                          | Instantaneous count of bytes allocated on the main heap and still in use
- DopplerServer.memoryStats.numBytesAllocatedStack                         | Instantaneous count of bytes used by the stack allocator
- DopplerServer.memoryStats.numFrees                                       | Lifetime number of memory deallocations
- DopplerServer.memoryStats.numMallocs                                     | Lifetime number of memory allocations
- DopplerServer.messageRouter.numberOfContainerMetricSinks                 | Instantaneous number of container metric sinks known to the SinkManager
- DopplerServer.messageRouter.numberOfDumpSinks                            | Instantaneous number of dump sinks known to the SinkManager
- DopplerServer.messageRouter.numberOfFirehoseSinks                        | Instantaneous number of firehose sinks known to the SinkManager
- DopplerServer.messageRouter.numberOfSyslogSinks                          | Instantaneous number of syslog sinks known to the SinkManager
- DopplerServer.messageRouter.numberOfWebsocketSinks                       | Instantaneous number of websocket sinks known to the SinkManager
- DopplerServer.messageRouter.totalDroppedMessages                         | Lifetime number of messages dropped inside Doppler for various reasons (downstream consumer can't keep up internal object wasn't ready for message, etc.)
- DopplerServer.sentMessagesFirehose.<SUBSCRIPTION_ID>                     | Number of sent messages through the firehose per subscription id
- DopplerServer.udpListener.receivedByteCount				  | Lifetime number of bytes received by Doppler's UDP Listener
- DopplerServer.udpListener.receivedMessageCount				  | Lifetime number of messages received by Doppler's UDP Listener
- DopplerServer.udpListener.receivedErrorCount				  | Lifetime number of errors encountered by Doppler's UDP Listener while reading from the connection
- DopplerServer.tcpListener.receivedByteCount				  | Lifetime number of bytes received by Doppler's TCP Listener
- DopplerServer.tcpListener.receivedMessageCount				  | Lifetime number of messages received by Doppler's TCP Listener
- DopplerServer.tcpListener.receivedErrorCount				  | Lifetime number of errors encountered by Doppler's TCP Listener while handshaking, decoding or reading from the connection
- DopplerServer.tlsListener.receivedByteCount				  | Lifetime number of bytes received by Doppler's TLS Listener
- DopplerServer.tlsListener.receivedMessageCount				  | Lifetime number of messages received by Doppler's TLS Listener
- DopplerServer.tlsListener.receivedErrorCount				  | Lifetime number of errors encountered by Doppler's TLS Listener while handshaking, decoding or reading from the connection
- DopplerServer.TruncatingBuffer.DroppedMessages				  | Number of messages intentionally dropped by Doppler from the sink for the specific sink. This counter event will correspond with log messages "Log message output is too high"
- DopplerServer.TruncatingBuffer.totalDroppedMessages			  | Lifetime total number of messages intentionally dropped by Doppler from all of its sinks due to back pressure
- DopplerServer.listeners.totalReceivedMessageCount			  | Total number of messages received across all of Doppler's listeners (UDP, TCP, TLS)
- DopplerServer.numCpus                                                    | Number of CPUs on the machine
- DopplerServer.numGoRoutines                                              | Instantaneous number of active Goroutines in the Doppler process
- DopplerServer.signatureVerifier.invalidSignatureErrors                   | Lifetime number of messages received with an invalid signature
- DopplerServer.signatureVerifier.missingSignatureErrors                   | Lifetime number of messages received that are too small to contain a signature
- DopplerServer.signatureVerifier.validSignatures                          | Lifetime number of messages received with valid signatures
+Default Origin Name: DopplerServer
+
+Metric Name                                                 | Description
+------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------
+ dropsondeListener.currentBufferCount                       | DEPRECATED
+ dropsondeListener.receivedByteCount                        | DEPRECATED in favor of DopplerServer.udpListener.receivedByteCount
+ dropsondeListener.receivedMessageCount                     | DEPRECATED in favor of DopplerServer.udpListener.receivedMessageCount
+ dropsondeUnmarshaller.containerMetricReceived              | Lifetime number of ContainerMetric messages unmarshalled
+ dropsondeUnmarshaller.counterEventReceived                 | Lifetime number of CounterEvent messages unmarshalled
+ dropsondeUnmarshaller.errorReceived                        | Lifetime number of Error messages unmarshalled
+ dropsondeUnmarshaller.heartbeatReceived                    | DEPRECATED
+ dropsondeUnmarshaller.httpStartReceived                    | Lifetime number of HttpStart messages unmarshalled
+ dropsondeUnmarshaller.httpStartStopReceived                | Lifetime number of HttpStartStop messages unmarshalled
+ dropsondeUnmarshaller.httpStopReceived                     | Lifetime number of HttpStop messages unmarshalled
+ dropsondeUnmarshaller.logMessageTotal                      | Lifetime number of LogMessage messages unmarshalled
+ dropsondeUnmarshaller.unmarshalErrors                      | Lifetime number of errors when unmarshalling messages
+ dropsondeUnmarshaller.valueMetricReceived                  | Lifetime number of ValueMetric messages unmarshalled
+ httpServer.receivedMessages                                | Number of messages received by Doppler's internal MessageRouter
+ LinuxFileDescriptor					    | Number of file handles for the Doppler's proccess
+ memoryStats.lastGCPauseTimeNS                              | Duration of the last Garbage Collector pause in nanoseconds
+ memoryStats.numBytesAllocated                              | Instantaneous count of bytes allocated and still in use
+ memoryStats.numBytesAllocatedHeap                          | Instantaneous count of bytes allocated on the main heap and still in use
+ memoryStats.numBytesAllocatedStack                         | Instantaneous count of bytes used by the stack allocator
+ memoryStats.numFrees                                       | Lifetime number of memory deallocations
+ memoryStats.numMallocs                                     | Lifetime number of memory allocations
+ messageRouter.numberOfContainerMetricSinks                 | Instantaneous number of container metric sinks known to the SinkManager
+ messageRouter.numberOfDumpSinks                            | Instantaneous number of dump sinks known to the SinkManager
+ messageRouter.numberOfFirehoseSinks                        | Instantaneous number of firehose sinks known to the SinkManager
+ messageRouter.numberOfSyslogSinks                          | Instantaneous number of syslog sinks known to the SinkManager
+ messageRouter.numberOfWebsocketSinks                       | Instantaneous number of websocket sinks known to the SinkManager
+ messageRouter.totalDroppedMessages                         | Lifetime number of messages dropped inside Doppler for various reasons (downstream consumer can't keep up internal object wasn't ready for message, etc.)
+ sentMessagesFirehose.<SUBSCRIPTION_ID>                     | Number of sent messages through the firehose per subscription id
+ udpListener.receivedByteCount				    | Lifetime number of bytes received by Doppler's UDP Listener
+ udpListener.receivedMessageCount			    | Lifetime number of messages received by Doppler's UDP Listener
+ udpListener.receivedErrorCount				    | Lifetime number of errors encountered by Doppler's UDP Listener while reading from the connection
+ tcpListener.receivedByteCount				    | Lifetime number of bytes received by Doppler's TCP Listener
+ tcpListener.receivedMessageCount			    | Lifetime number of messages received by Doppler's TCP Listener
+ tcpListener.receivedErrorCount				    | Lifetime number of errors encountered by Doppler's TCP Listener while handshaking, decoding or reading from the connection
+ tlsListener.receivedByteCount				    | Lifetime number of bytes received by Doppler's TLS Listener
+ tlsListener.receivedMessageCount			    | Lifetime number of messages received by Doppler's TLS Listener
+ tlsListener.receivedErrorCount				    | Lifetime number of errors encountered by Doppler's TLS Listener while handshaking, decoding or reading from the connection
+ TruncatingBuffer.DroppedMessages			    | Number of messages intentionally dropped by Doppler from the sink for the specific sink. This counter event will correspond with log messages "Log message output is too high"
+ TruncatingBuffer.totalDroppedMessages			    | Lifetime total number of messages intentionally dropped by Doppler from all of its sinks due to back pressure
+ listeners.totalReceivedMessageCount			    | Total number of messages received across all of Doppler's listeners (UDP, TCP, TLS)
+ numCpus                                                    | Number of CPUs on the machine
+ numGoRoutines                                              | Instantaneous number of active Goroutines in the Doppler process
+ signatureVerifier.invalidSignatureErrors                   | Lifetime number of messages received with an invalid signature
+ signatureVerifier.missingSignatureErrors                   | Lifetime number of messages received that are too small to contain a signature
+ signatureVerifier.validSignatures                          | Lifetime number of messages received with valid signatures
+ Uptime							    | Uptime for the Doppler's process
 
 [Top](#metrics-by-component)

--- a/metrics/_metron_agent.html.md.erb
+++ b/metrics/_metron_agent.html.md.erb
@@ -56,4 +56,4 @@ Metric Name                                   | Description
  udp.sentMessageCount			       | Lifetime number of sent messages to Doppler over UDP
 
 
-[Top](#metrics-by-component)
+[Top](#top)

--- a/metrics/_metron_agent.html.md.erb
+++ b/metrics/_metron_agent.html.md.erb
@@ -1,3 +1,5 @@
+Default Origin Name: MetronAgent
+
 Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
  MessageAggregator.counterEventReceived        | Lifetime number of CounterEvents aggregated in Metron

--- a/metrics/_syslog_drain_binder.html.md.erb
+++ b/metrics/_syslog_drain_binder.html.md.erb
@@ -1,14 +1,16 @@
-Metric Name                                            | Description
---------------------------------------------------------|---------------------------------------------------------------------------------------------------
- syslog\_drain\_binder.memoryStats.lastGCPauseTimeNS      | Duration of the last Garbage Collector pause in nanoseconds
- syslog\_drain\_binder.memoryStats.numBytesAllocated      | Instantaneous count of bytes allocated and still in use
- syslog\_drain\_binder.memoryStats.numBytesAllocatedHeap  | Instantaneous count of bytes allocated on the main heap and still in use
- syslog\_drain\_binder.memoryStats.numBytesAllocatedStack | Instantaneous count of bytes used by the stack allocator
- syslog\_drain\_binder.memoryStats.numFrees               | Lifetime number of memory deallocations
- syslog\_drain\_binder.memoryStats.numMallocs             | Lifetime number of memory allocations
- syslog\_drain\_binder.numCPUS                            | Number of CPUs on the machine
- syslog\_drain\_binder.numGoRoutines                      | Instantaneous number of active Goroutines in the Doppler process
- syslog\_drain\_binder.pollCount                          | Number of times the syslog drain binder has polled the cloud controller for syslog drain bindings
- syslog\_drain\_binder.totalDrains                        | Number of syslog drains returned by cloud controller
+Default Origin Name: syslog_drain_binder
+
+Metric Name                         | Description
+------------------------------------|---------------------------------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS      | Duration of the last Garbage Collector pause in nanoseconds
+ memoryStats.numBytesAllocated      | Instantaneous count of bytes allocated and still in use
+ memoryStats.numBytesAllocatedHeap  | Instantaneous count of bytes allocated on the main heap and still in use
+ memoryStats.numBytesAllocatedStack | Instantaneous count of bytes used by the stack allocator
+ memoryStats.numFrees               | Lifetime number of memory deallocations
+ memoryStats.numMallocs             | Lifetime number of memory allocations
+ numCPUS                            | Number of CPUs on the machine
+ numGoRoutines                      | Instantaneous number of active Goroutines in the Doppler process
+ pollCount                          | Number of times the syslog drain binder has polled the cloud controller for syslog drain bindings
+ totalDrains                        | Number of syslog drains returned by cloud controller
 
 [Top](#metrics-by-component)

--- a/metrics/_syslog_drain_binder.html.md.erb
+++ b/metrics/_syslog_drain_binder.html.md.erb
@@ -1,4 +1,4 @@
-Default Origin Name: syslog_drain_binder
+Default Origin Name: syslog\_drain\_binder
 
 Metric Name                         | Description
 ------------------------------------|---------------------------------------------------------------------------------------------------
@@ -13,4 +13,4 @@ Metric Name                         | Description
  pollCount                          | Number of times the syslog drain binder has polled the cloud controller for syslog drain bindings
  totalDrains                        | Number of syslog drains returned by cloud controller
 
-[Top](#metrics-by-component)
+[Top](#top)

--- a/metrics/_traffic_controller.html.md.erb
+++ b/metrics/_traffic_controller.html.md.erb
@@ -15,4 +15,4 @@ Metric Name                           | Description
  Uptime				       | Uptime for the Traffic Controller's process
  LinuxFileDescriptor                   | Number of file handles for the TrafficController's proccess
 
-[Top](#metrics-by-component)
+[Top](#top)

--- a/metrics/_traffic_controller.html.md.erb
+++ b/metrics/_traffic_controller.html.md.erb
@@ -1,15 +1,18 @@
- Metric Name                                                        | Description
---------------------------------------------------------------------|--------------------------------------------------------------------------
- LoggregatorTrafficController.dopplerProxy.containermetricsLatency  | Duration for serving container metrics via the containermetrics endpoint (milliseconds)
- LoggregatorTrafficController.dopplerProxy.recentlogsLatency	    | Duration for serving recent logs via the recentLogs endpoint (milliseconds)
- LoggregatorTrafficController.memoryStats.lastGCPauseTimeNS	    | Duration of the last Garbage Collector pause in nanoseconds
- LoggregatorTrafficController.memoryStats.numBytesAllocated         | Instantaneous count of bytes allocated and still in use
- LoggregatorTrafficController.memoryStats.numBytesAllocatedHeap     | Instantaneous count of bytes allocated on the main heap and still in use
- LoggregatorTrafficController.memoryStats.numBytesAllocatedStack    | Instantaneous count of bytes used by the stack allocator
- LoggregatorTrafficController.memoryStats.numFrees                  | Lifetime number of memory deallocations
- LoggregatorTrafficController.memoryStats.numMallocs                | Lifetime number of memory allocations
- LoggregatorTrafficController.numCPUS                               | Number of CPUs on the machine
- LoggregatorTrafficController.numGoRoutines                         | Instantaneous number of active Goroutines in the Doppler process
- LoggregatorTrafficController.Uptime				    | Uptime for the Traffic Controller's process
+Default Origin Name: LoggregatorTrafficController
+
+Metric Name                           | Description
+---------------------------------------|-----------------------------------------------------------------------------------------
+ dopplerProxy.containermetricsLatency  | Duration for serving container metrics via the containermetrics endpoint (milliseconds)
+ dopplerProxy.recentlogsLatency	       | Duration for serving recent logs via the recentLogs endpoint (milliseconds)
+ memoryStats.lastGCPauseTimeNS	       | Duration of the last Garbage Collector pause in nanoseconds
+ memoryStats.numBytesAllocated         | Instantaneous count of bytes allocated and still in use
+ memoryStats.numBytesAllocatedHeap     | Instantaneous count of bytes allocated on the main heap and still in use
+ memoryStats.numBytesAllocatedStack    | Instantaneous count of bytes used by the stack allocator
+ memoryStats.numFrees                  | Lifetime number of memory deallocations
+ memoryStats.numMallocs                | Lifetime number of memory allocations
+ numCPUS                               | Number of CPUs on the machine
+ numGoRoutines                         | Instantaneous number of active Goroutines in the Doppler process
+ Uptime				       | Uptime for the Traffic Controller's process
+ LinuxFileDescriptor                   | Number of file handles for the TrafficController's proccess
 
 [Top](#metrics-by-component)


### PR DESCRIPTION
- Adds a line to each section stating the default origin name.

The metric names for Loggregator components are truly the metric names emitted by the components. I added a line about the origin name because some consumers prepend the origin name to the metric name thus confusing the audience into thinking that its part of the metric name.

[#119567343]