### PR TITLE
Document metrics emitted by routing components

### DIFF
--- a/all_metrics.html.md.erb
+++ b/all_metrics.html.md.erb
@@ -32,3 +32,7 @@ owner: Logging and Metrics
 
 ##<a id='uaa'></a>User Account and Authentication (UAA)
 <%= partial './metrics/uaa' %>
+
+##<a id='routing'></a>Routing
+<%= partial './metrics/routing' %>
+

--- a/metrics/_routing.html.md.erb
+++ b/metrics/_routing.html.md.erb
@@ -2,9 +2,9 @@ Routing Release metrics have following origin names:
 
 
 + [gorouter](#gorouter)
-+ [tcp_router] (#tcprouter)
++ [tcp_router] (#tcp_router)
 + [tcp_emitter] (#tcp_emitter)
-+ [routing_api] (#routingapi)<a id="gorouter"></a>
++ [routing_api] (#routing_api)<a id="gorouter"></a>
 
 
 Default Origin Name: gorouter
@@ -64,13 +64,13 @@ Metric Name                                   | Description
  numCpus                                       | Number of CPUs on the machine
  numGoRoutines                                 | Instantaneous number of active Goroutines in the Doppler process
  udp.sentMessageCount			       | Lifetime number of sent messages to Doppler over UDP
- udp.sentByteCount			       | Lifetime number of sent bytes to Doppler over UDP<a id="routing_api"></a>
+ udp.sentByteCount			       | Lifetime number of sent bytes to Doppler over UDP
  TotalBackendConnectionErrors		       | Total number of backend connection errors
  TotalCurrentQueuedRequests		       | Total number of requests unassigned in queue
  AverageQueueTimeMs			       | Average time spent in queue (in ms)
  AverageConnectTimeMs			       | Average backend response time (in ms)
  {session_id}CurrentSessions		       | Total number of current sessions
- {session_id}.ConnectionTime		       | Average connection time to backend in current session
+ {session_id}.ConnectionTime		       | Average connection time to backend in current session<a id="routing_api"></a>
 
 
 Default Origin Name: routing_api

--- a/metrics/_routing.html.md.erb
+++ b/metrics/_routing.html.md.erb
@@ -9,7 +9,7 @@ Routing Release metrics have following origin names:
 
 Default Origin Name: gorouter
 
-Metric Name                                   | Description
+ Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
  memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds
  memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use
@@ -17,6 +17,7 @@ Metric Name                                   | Description
  memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator
  memoryStats.numFrees                          | Lifetime number of memory deallocations
  memoryStats.numMallocs                        | Lifetime number of memory allocations
+ logSenderTotalMessagesRead                    | Count of application log messages
  numCpus                                       | Number of CPUs on the machine
  numGoRoutines                                 | Instantaneous number of active Goroutines in the Doppler process
  responses				       | Total number of http responses
@@ -39,7 +40,7 @@ Metric Name                                   | Description
 
 Default Origin Name: tcp_emitter
 
-Metric Name                                   | Description
+ Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
  memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds
  memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use
@@ -49,11 +50,13 @@ Metric Name                                   | Description
  memoryStats.numMallocs                        | Lifetime number of memory allocations
  numCpus                                       | Number of CPUs on the machine
  numGoRoutines                                 | Instantaneous number of active Goroutines in the Doppler process<a id="tcp_router"></a>
+ udp.sentMessageCount			       | Lifetime number of sent messages to Doppler over UDP
+ udp.sentByteCount			       | Lifetime number of sent bytes to Doppler over UDP
 
 
-Default Origin Name: tcp_router
+Default Origin Name: router_configurer
 
-Metric Name                                   | Description
+ Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
  memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds
  memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use
@@ -75,7 +78,7 @@ Metric Name                                   | Description
 
 Default Origin Name: routing_api
 
-Metric Name                                   | Description
+ Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
  memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds
  memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use

--- a/metrics/_routing.html.md.erb
+++ b/metrics/_routing.html.md.erb
@@ -2,12 +2,12 @@ Routing Release metrics have following origin names:
 
 
 + [gorouter](#gorouter)
-+ [tcp_router] (#tcp_router)
 + [tcp_emitter] (#tcp_emitter)
-+ [routing_api] (#routing_api)<a id="gorouter"></a>
++ [tcp_router] (#tcp_router)
++ [routing_api] (#routing_api)
 
 
-Default Origin Name: gorouter
+<a id="gorouter"></a>Default Origin Name: gorouter
 
  Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
@@ -35,10 +35,10 @@ Default Origin Name: gorouter
  ms_since_last_registry_update		       | Time in millisecond since the last route register has been been receieved
  bad_gateways				       | Total number of Bad gateways
  latency				       | Time the Gorouter took to handle requests to its application endpoints. Emitted when the Gorouter handles requests
- latency.{component}			       | Time the Gorouter took to handle requests from each component to its endpoints. Emitted when the Gorouter handles requests<a id="tcp_emitter"></a>
+ latency.{component}			       | Time the Gorouter took to handle requests from each component to its endpoints. Emitted when the Gorouter handles requests
 
 
-Default Origin Name: tcp_emitter
+<a id="tcp_emitter"></a>Default Origin Name: tcp_emitter
 
  Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
@@ -49,12 +49,12 @@ Default Origin Name: tcp_emitter
  memoryStats.numFrees                          | Lifetime number of memory deallocations
  memoryStats.numMallocs                        | Lifetime number of memory allocations
  numCpus                                       | Number of CPUs on the machine
- numGoRoutines                                 | Instantaneous number of active Goroutines in the Doppler process<a id="tcp_router"></a>
+ numGoRoutines                                 | Instantaneous number of active Goroutines in the Doppler process
  udp.sentMessageCount			       | Lifetime number of sent messages to Doppler over UDP
  udp.sentByteCount			       | Lifetime number of sent bytes to Doppler over UDP
 
 
-Default Origin Name: router_configurer
+<a id="tcp_router"></a>Default Origin Name: router_configurer (bosh job tcp_router)
 
  Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
@@ -73,10 +73,10 @@ Default Origin Name: router_configurer
  AverageQueueTimeMs			       | Average time spent in queue (in ms)
  AverageConnectTimeMs			       | Average backend response time (in ms)
  {session_id}CurrentSessions		       | Total number of current sessions
- {session_id}.ConnectionTime		       | Average connection time to backend in current session<a id="routing_api"></a>
+ {session_id}.ConnectionTime		       | Average connection time to backend in current session
 
 
-Default Origin Name: routing_api
+<a id="routing_api"></a>Default Origin Name: routing_api
 
  Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------

--- a/metrics/_routing.html.md.erb
+++ b/metrics/_routing.html.md.erb
@@ -1,0 +1,97 @@
+Routing Release metrics have following origin names: 
+
+
++ [gorouter](#gorouter)
++ [tcp_router] (#tcprouter)
++ [tcp_emitter] (#tcp_emitter)
++ [routing_api] (#routingapi)<a id="gorouter"></a>
+
+
+Default Origin Name: gorouter
+
+Metric Name                                   | Description
+-----------------------------------------------|----------------------------------------------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds
+ memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use
+ memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use
+ memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator
+ memoryStats.numFrees                          | Lifetime number of memory deallocations
+ memoryStats.numMallocs                        | Lifetime number of memory allocations
+ numCpus                                       | Number of CPUs on the machine
+ numGoRoutines                                 | Instantaneous number of active Goroutines in the Doppler process
+ responses				       | Total number of http responses
+ responses.2xx				       | Total number of 2xx http responses
+ responses.3xx				       | Total number of 3xx http responses
+ responses.4xx				       | Total number of 4xx http responses
+ responses.5xx				       | Total number of 5xx http responses
+ responses.xxx				       | Total number of other(non-(2xx-5xx)) http responses
+ routed_app_requests			       | The collector sums up requests for all dea-{index} components for its output metrics.
+ total_requests				       | Total number of requests receieved
+ total_routes				       | Total number of routes registered
+ registry_message.{components}		       | Total number of route register messages received for each component
+ rejected_requests			       | Total number of bad requests received on gorouter
+ requests.{component_name}		       | Total number of requests receieved for each component
+ ms_since_last_registry_update		       | Time in millisecond since the last route register has been been receieved
+ bad_gateways				       | Total number of Bad gateways
+ latency				       | Time the Gorouter took to handle requests to its application endpoints. Emitted when the Gorouter handles requests
+ latency.{component}			       | Time the Gorouter took to handle requests from each component to its endpoints. Emitted when the Gorouter handles requests<a id="tcp_emitter"></a>
+
+
+Default Origin Name: tcp_emitter
+
+Metric Name                                   | Description
+-----------------------------------------------|----------------------------------------------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds
+ memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use
+ memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use
+ memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator
+ memoryStats.numFrees                          | Lifetime number of memory deallocations
+ memoryStats.numMallocs                        | Lifetime number of memory allocations
+ numCpus                                       | Number of CPUs on the machine
+ numGoRoutines                                 | Instantaneous number of active Goroutines in the Doppler process<a id="tcp_router"></a>
+
+
+Default Origin Name: tcp_router
+
+Metric Name                                   | Description
+-----------------------------------------------|----------------------------------------------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds
+ memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use
+ memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use
+ memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator
+ memoryStats.numFrees                          | Lifetime number of memory deallocations
+ memoryStats.numMallocs                        | Lifetime number of memory allocations
+ numCpus                                       | Number of CPUs on the machine
+ numGoRoutines                                 | Instantaneous number of active Goroutines in the Doppler process
+ udp.sentMessageCount			       | Lifetime number of sent messages to Doppler over UDP
+ udp.sentByteCount			       | Lifetime number of sent bytes to Doppler over UDP<a id="routing_api"></a>
+ TotalBackendConnectionErrors		       | Total number of backend connection errors
+ TotalCurrentQueuedRequests		       | Total number of requests unassigned in queue
+ AverageQueueTimeMs			       | Average time spent in queue (in ms)
+ AverageConnectTimeMs			       | Average backend response time (in ms)
+ {session_id}CurrentSessions		       | Total number of current sessions
+ {session_id}.ConnectionTime		       | Average connection time to backend in current session
+
+
+Default Origin Name: routing_api
+
+Metric Name                                   | Description
+-----------------------------------------------|----------------------------------------------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds
+ memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use
+ memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use
+ memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator
+ memoryStats.numFrees                          | Lifetime number of memory deallocations
+ memoryStats.numMallocs                        | Lifetime number of memory allocations
+ numCpus                                       | Number of CPUs on the machine
+ numGoRoutines                                 | Instantaneous number of active Goroutines in the Doppler process
+ udp.sentMessageCount			       | Lifetime number of sent messages to Doppler over UDP
+ udp.sentByteCount			       | Lifetime number of sent bytes to Doppler over UDP
+ total_http_routes			       | Number of tcp routes in the  routing table. Emitted periodically
+ total_http_subscription		       | Number of http routes subscripions
+ total_token_errors			       | Total number of UAA token errors
+ key_refresh_events			       | Total number of events when fresh token was fetched from UAA
+ total_tcp_routes			       | Number of tcp routes in the routing table. Emitted periodically
+ total_tcp_subscriptions		       | Number of tcp routes subscripions
+
+ [Top](#top)


### PR DESCRIPTION
Hi, 

This PR will list the metrics available for all routing components through firehose. Routing components include routing-api, tcp-emitter, tcp-router (both router-configurer and haproxy) and gorouter.

Regards
Shash
CF Routing Team