### PR TITLE
Update routing metrics with correct intervals

### DIFF
--- a/metrics/_routing.html.md.erb
+++ b/metrics/_routing.html.md.erb
@@ -9,86 +9,86 @@ Routing Release metrics have following origin names:
 
 <a id="gorouter"></a>Default Origin Name: gorouter
 
- Metric Name                                   | Description
------------------------------------------------|----------------------------------------------------------------------------------------------------------------
- memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
- memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
- memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
- memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
- memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 10 seconds
- memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 10 seconds
- numCPUS                                       | Number of CPUs on the machine. Emitted every 10 seconds
- numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
- logSenderTotalMessagesRead                    | Count of application log messages. Emitted every 5 seconds
- bad\_gateways                                 | Total number of bad gateways. Emitted every 5 seconds
- latency                                       | Time the Gorouter took to handle requests to its application endpoints. Emitted per router request
- latency.{component}                           | Time the Gorouter took to handle requests from each component to its endpoints. Emitted per router request
- registry\_message.{component}                 | Total number of route register messages received for each component. Emitted per route-register message
- rejected\_requests                            | Total number of bad requests received on gorouter. Emitted every 5 seconds
- requests.{component}                          | Total number of requests received for each component. Emitted every 5 seconds
- responses                                     | Total number of HTTP responses. Emitted every 5 seconds
- responses.2xx                                 | Total number of 2xx HTTP responses. Emitted every 5 seconds
- responses.3xx                                 | Total number of 3xx HTTP response. Emitted every 5 seconds
- responses.4xx                                 | Total number of 4xx HTTP response. Emitted every 5 seconds
- responses.5xx                                 | Total number of 5xx HTTP response. Emitted every 5 seconds
- responses.xxx                                 | Total number of other(non-(2xx-5xx)) HTTP response. Emitted every 5 seconds
- routed\_app\_requests                         | The collector sums up requests for all dea-{index} components for its output metrics. Emitted every 5 seconds
- total\_requests                               | Total number of requests received. Emitted every 5 seconds
- ms\_since\_last\_registry\_update             | Time in millisecond since the last route register has been been received. Emitted every 30 seconds
- total\_routes                                 | Total number of routes registered. Emitted every 30 seconds
- uptime                                        | Uptime for router. Emitted every second
+ Metric Name                        | Description
+------------------------------------|----------------------------------------------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS      | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
+ memoryStats.numBytesAllocated      | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedHeap  | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedStack | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
+ memoryStats.numFrees               | Lifetime number of memory deallocations. Emitted every 10 seconds
+ memoryStats.numMallocs             | Lifetime number of memory allocations. Emitted every 10 seconds
+ numCPUS                            | Number of CPUs on the machine. Emitted every 10 seconds
+ numGoRoutines                      | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
+ logSenderTotalMessagesRead         | Count of application log messages. Emitted every 5 seconds
+ bad\_gateways                      | Total number of bad gateways. Emitted every 5 seconds
+ latency                            | Time the Gorouter took to handle requests to its application endpoints. Emitted per router request
+ latency.{component}                | Time the Gorouter took to handle requests from each component to its endpoints. Emitted per router request
+ registry\_message.{component}      | Total number of route register messages received for each component. Emitted per route-register message
+ rejected\_requests                 | Total number of bad requests received on gorouter. Emitted every 5 seconds
+ requests.{component}               | Total number of requests received for each component. Emitted every 5 seconds
+ responses                          | Total number of HTTP responses. Emitted every 5 seconds
+ responses.2xx                      | Total number of 2xx HTTP responses. Emitted every 5 seconds
+ responses.3xx                      | Total number of 3xx HTTP response. Emitted every 5 seconds
+ responses.4xx                      | Total number of 4xx HTTP response. Emitted every 5 seconds
+ responses.5xx                      | Total number of 5xx HTTP response. Emitted every 5 seconds
+ responses.xxx                      | Total number of other(non-(2xx-5xx)) HTTP response. Emitted every 5 seconds
+ routed\_app\_requests              | The collector sums up requests for all dea-{index} components for its output metrics. Emitted every 5 seconds
+ total\_requests                    | Total number of requests received. Emitted every 5 seconds
+ ms\_since\_last\_registry\_update  | Time in millisecond since the last route register has been been received. Emitted every 30 seconds
+ total\_routes                      | Total number of routes registered. Emitted every 30 seconds
+ uptime                             | Uptime for router. Emitted every second
 
 <a id="routing_api"></a>Default Origin Name: routing_api
 
- Metric Name                                   | Description
------------------------------------------------|----------------------------------------------------------------------------------------------------------------
- memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
- memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
- memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
- memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
- memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 10 seconds
- memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 10 seconds
- numCPUS                                       | Number of CPUs on the machine. Emitted every 10 seconds
- numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
- key\_refresh\_events                          | Total number of events when fresh token was fetched from UAA. Emitted every 30 seconds
- total\_http\_routes                           | Number of HTTP routes in the routing table. Emitted every 30 seconds, or when there is a new HTTP route added. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
- total\_http\_subscriptions                    | Number of HTTP routes subscriptions. Emitted every 30 seconds. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
- total\_tcp\_routes                            | Number of TCP routes in the routing table. Emitted every 30 seconds, or when there is a new TCP route added. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
- total\_tcp\_subscriptions                     | Number of TCP routes subscriptions. Emitted every 30 seconds. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
- total\_token\_errors                          | Total number of UAA token errors. Emitted every 30 seconds. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
+ Metric Name                        | Description
+------------------------------------|----------------------------------------------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS      | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
+ memoryStats.numBytesAllocated      | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedHeap  | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedStack | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
+ memoryStats.numFrees               | Lifetime number of memory deallocations. Emitted every 10 seconds
+ memoryStats.numMallocs             | Lifetime number of memory allocations. Emitted every 10 seconds
+ numCPUS                            | Number of CPUs on the machine. Emitted every 10 seconds
+ numGoRoutines                      | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
+ key\_refresh\_events               | Total number of events when fresh token was fetched from UAA. Emitted every 30 seconds
+ total\_http\_routes                | Number of HTTP routes in the routing table. Emitted every 30 seconds, or when there is a new HTTP route added. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
+ total\_http\_subscriptions         | Number of HTTP routes subscriptions. Emitted every 30 seconds. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
+ total\_tcp\_routes                 | Number of TCP routes in the routing table. Emitted every 30 seconds, or when there is a new TCP route added. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
+ total\_tcp\_subscriptions          | Number of TCP routes subscriptions. Emitted every 30 seconds. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
+ total\_token\_errors               | Total number of UAA token errors. Emitted every 30 seconds. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
 
 <a id="tcp_emitter"></a>Default Origin Name: tcp_emitter
 
- Metric Name                                   | Description
------------------------------------------------|----------------------------------------------------------------------------------------------------------------
- memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
- memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
- memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
- memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
- memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 10 seconds
- memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 10 seconds
- numCPUS                                       | Number of CPUs on the machine. Emitted every 10 seconds
- numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
+ Metric Name                        | Description
+------------------------------------|----------------------------------------------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS      | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
+ memoryStats.numBytesAllocated      | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedHeap  | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedStack | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
+ memoryStats.numFrees               | Lifetime number of memory deallocations. Emitted every 10 seconds
+ memoryStats.numMallocs             | Lifetime number of memory allocations. Emitted every 10 seconds
+ numCPUS                            | Number of CPUs on the machine. Emitted every 10 seconds
+ numGoRoutines                      | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
 
 
 <a id="tcp_router"></a>Default Origin Name: router\_configurer (bosh job tcp_router)
 
- Metric Name                                   | Description
------------------------------------------------|----------------------------------------------------------------------------------------------------------------
- memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
- memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
- memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
- memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
- memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 10 seconds
- memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 10 seconds
- numCPUS                                       | Number of CPUs on the machine. Emitted every 10 seconds
- numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
- {session_id}.ConnectionTime                   | Average connection time to backend in current session. Emitted every 60 seconds per session ID. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
- {session_id}.CurrentSessions                  | Total number of current sessions. Emitted every 60 seconds per session ID. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
- AverageConnectTimeMs                          | Average backend response time (in ms). Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
- AverageQueueTimeMs                            | Average time spent in queue (in ms). Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
- TotalBackendConnectionErrors                  | Total number of backend connection errors. Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
- TotalCurrentQueuedRequests                    | Total number of requests unassigned in queue. Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ Metric Name                        | Description
+------------------------------------|----------------------------------------------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS      | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
+ memoryStats.numBytesAllocated      | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedHeap  | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedStack | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
+ memoryStats.numFrees               | Lifetime number of memory deallocations. Emitted every 10 seconds
+ memoryStats.numMallocs             | Lifetime number of memory allocations. Emitted every 10 seconds
+ numCPUS                            | Number of CPUs on the machine. Emitted every 10 seconds
+ numGoRoutines                      | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
+ {session_id}.ConnectionTime        | Average connection time to backend in current session. Emitted every 60 seconds per session ID. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ {session_id}.CurrentSessions       | Total number of current sessions. Emitted every 60 seconds per session ID. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ AverageConnectTimeMs               | Average backend response time (in ms). Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ AverageQueueTimeMs                 | Average time spent in queue (in ms). Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ TotalBackendConnectionErrors       | Total number of backend connection errors. Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ TotalCurrentQueuedRequests         | Total number of requests unassigned in queue. Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
 
 
  [Top](#top)

--- a/metrics/_routing.html.md.erb
+++ b/metrics/_routing.html.md.erb
@@ -11,90 +11,84 @@ Routing Release metrics have following origin names:
 
  Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
- bad\_gateways                                 | Total number of bad gateways. Emitted every 30 seconds
- latency                                       | Time the Gorouter took to handle requests to its application endpoints. Emitted when the Gorouter handles requests
- latency.{component}                           | Time the Gorouter took to handle requests from each component to its endpoints. Emitted when the Gorouter handles requests
- logSenderTotalMessagesRead                    | Count of application log messages. Emitted every 30 seconds
- memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 30 seconds
- memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 30 seconds
- memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 30 seconds
- memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 30 seconds
- memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 30 seconds
- memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 30 seconds
- ms\_since\_last\_registry\_update             | Time in millisecond since the last route register has been been received. Emitted every 30 seconds
- numCpus                                       | Number of CPUs on the machine. Emitted every 30 seconds
- numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted per router request
+ memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
+ memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
+ memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 10 seconds
+ memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 10 seconds
+ numCPUS                                       | Number of CPUs on the machine. Emitted every 10 seconds
+ numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
+ logSenderTotalMessagesRead                    | Count of application log messages. Emitted every 5 seconds
+ bad\_gateways                                 | Total number of bad gateways. Emitted every 5 seconds
+ latency                                       | Time the Gorouter took to handle requests to its application endpoints. Emitted per router request
+ latency.{component}                           | Time the Gorouter took to handle requests from each component to its endpoints. Emitted per router request
  registry\_message.{component}                 | Total number of route register messages received for each component. Emitted per route-register message
- rejected\_requests                            | Total number of bad requests received on gorouter. Emitted every 30 seconds
- requests.{component}                          | Total number of requests received for each component. Emitted per router request
- responses                                     | Total number of HTTP responses. Emitted per router request
- responses.2xx                                 | Total number of 2xx HTTP responses. Emitted per router request
- responses.3xx                                 | Total number of 3xx HTTP response. Emitted per router request
- responses.4xx                                 | Total number of 4xx HTTP response. Emitted per router request
- responses.5xx                                 | Total number of 5xx HTTP response. Emitted per router request
- responses.xxx                                 | Total number of other(non-(2xx-5xx)) HTTP response. Emitted per router request
- routed\_app\_requests                         | The collector sums up requests for all dea-{index} components for its output metrics. Emitted every 30 seconds
- total\_requests                               | Total number of requests received. Emitted every 30 seconds
+ rejected\_requests                            | Total number of bad requests received on gorouter. Emitted every 5 seconds
+ requests.{component}                          | Total number of requests received for each component. Emitted every 5 seconds
+ responses                                     | Total number of HTTP responses. Emitted every 5 seconds
+ responses.2xx                                 | Total number of 2xx HTTP responses. Emitted every 5 seconds
+ responses.3xx                                 | Total number of 3xx HTTP response. Emitted every 5 seconds
+ responses.4xx                                 | Total number of 4xx HTTP response. Emitted every 5 seconds
+ responses.5xx                                 | Total number of 5xx HTTP response. Emitted every 5 seconds
+ responses.xxx                                 | Total number of other(non-(2xx-5xx)) HTTP response. Emitted every 5 seconds
+ routed\_app\_requests                         | The collector sums up requests for all dea-{index} components for its output metrics. Emitted every 5 seconds
+ total\_requests                               | Total number of requests received. Emitted every 5 seconds
+ ms\_since\_last\_registry\_update             | Time in millisecond since the last route register has been been received. Emitted every 30 seconds
  total\_routes                                 | Total number of routes registered. Emitted every 30 seconds
+ uptime                                        | Uptime for router. Emitted every second
 
 <a id="routing_api"></a>Default Origin Name: routing_api
 
  Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
+ memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
+ memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
+ memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 10 seconds
+ memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 10 seconds
+ numCPUS                                       | Number of CPUs on the machine. Emitted every 10 seconds
+ numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
  key\_refresh\_events                          | Total number of events when fresh token was fetched from UAA. Emitted every 30 seconds
- memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 30 seconds
- memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 30 seconds
- memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 30 seconds
- memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 30 seconds
- memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 30 seconds
- memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 30 seconds
- numCpus                                       | Number of CPUs on the machine. Emitted every 30 seconds
- numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 30 seconds
- total\_http\_routes                           | Number of TCP routes in the  routing table. Emitted every 30 seconds
- total\_http\_subscription                     | Number of HTTP routes subscriptions. Emitted every 30 seconds
- total\_tcp\_routes                            | Number of TCP routes in the routing table. Emitted every 30 seconds
- total\_tcp\_subscriptions                     | Number of TCP routes subscriptions. Emitted every 30 seconds
- total\_token\_errors                          | Total number of UAA token errors. Emitted every 30 seconds
- udp.sentByteCount                             | Lifetime number of sent bytes to Doppler over UDP. Emitted every 30 seconds
- udp.sentMessageCount                          | Lifetim numbeyyyy sent messages to Doppler over UDP. Emitted every 30 seconds
+ total\_http\_routes                           | Number of HTTP routes in the routing table. Emitted every 30 seconds, or when there is a new HTTP route added. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
+ total\_http\_subscriptions                    | Number of HTTP routes subscriptions. Emitted every 30 seconds. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
+ total\_tcp\_routes                            | Number of TCP routes in the routing table. Emitted every 30 seconds, or when there is a new TCP route added. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
+ total\_tcp\_subscriptions                     | Number of TCP routes subscriptions. Emitted every 30 seconds. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
+ total\_token\_errors                          | Total number of UAA token errors. Emitted every 30 seconds. Interval for emitting this metric can be configured with manifest property `metrics_reporting_interval`
 
 <a id="tcp_emitter"></a>Default Origin Name: tcp_emitter
 
  Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
- memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 30 seconds
- memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 30 seconds
- memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 30 seconds
- memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 30 seconds
- memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 30 seconds
- memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 30 seconds
- numCpus                                       | Number of CPUs on the machine. Emitted every 30 seconds
- numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 30 seconds
- udp.sentByteCount                             | Lifetime number of sent bytes to Doppler over UDP. Emitted every 30 seconds
- udp.sentMessageCount                          | Lifetime number of sent messages to Doppler over UDP. Emitted every 30 seconds
+ memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
+ memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
+ memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 10 seconds
+ memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 10 seconds
+ numCPUS                                       | Number of CPUs on the machine. Emitted every 10 seconds
+ numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
 
 
 <a id="tcp_router"></a>Default Origin Name: router\_configurer (bosh job tcp_router)
 
  Metric Name                                   | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
- {session_id}.ConnectionTime                   | Average connection time to backend in current session. Emitted every 30 seconds
- {session_id}CurrentSessions                   | Total number of current sessions. Emitted every 30 seconds
- AverageConnectTimeMs                          | Average backend response time (in ms). Emitted every 30 seconds
- AverageQueueTimeMs                            | Average time spent in queue (in ms). Emitted every 30 seconds
- memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 30 seconds
- memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 30 seconds
- memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 30 seconds
- memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 30 seconds
- memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 30 seconds
- memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 30 seconds
- numCpus                                       | Number of CPUs on the machine. Emitted every 30 seconds
- numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 30 seconds
- TotalBackendConnectionErrors                  | Total number of backend connection errors. Emitted every 30 seconds
- TotalCurrentQueuedRequests                    | Total number of requests unassigned in queue. Emitted every 30 seconds
- udp.sentByteCount                             | Lifetime number of sent bytes to Doppler over UDP
- udp.sentMessageCount                          | Lifetime number of sent messages to Doppler over UDP. Emitted every 30 seconds
-
+ memoryStats.lastGCPauseTimeNS                 | Duration of the last Garbage Collector pause in nanoseconds. Emitted every 10 seconds
+ memoryStats.numBytesAllocated                 | Instantaneous count of bytes allocated and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedHeap             | Instantaneous count of bytes allocated on the main heap and still in use. Emitted every 10 seconds
+ memoryStats.numBytesAllocatedStack            | Instantaneous count of bytes used by the stack allocator. Emitted every 10 seconds
+ memoryStats.numFrees                          | Lifetime number of memory deallocations. Emitted every 10 seconds
+ memoryStats.numMallocs                        | Lifetime number of memory allocations. Emitted every 10 seconds
+ numCPUS                                       | Number of CPUs on the machine. Emitted every 10 seconds
+ numGoRoutines                                 | Instantaneous number of active goroutines in the Doppler process. Emitted every 10 seconds
+ {session_id}.ConnectionTime                   | Average connection time to backend in current session. Emitted every 60 seconds per session ID. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ {session_id}.CurrentSessions                  | Total number of current sessions. Emitted every 60 seconds per session ID. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ AverageConnectTimeMs                          | Average backend response time (in ms). Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ AverageQueueTimeMs                            | Average time spent in queue (in ms). Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ TotalBackendConnectionErrors                  | Total number of backend connection errors. Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
+ TotalCurrentQueuedRequests                    | Total number of requests unassigned in queue. Emitted every 60 seconds. Interval value for this metric can be configured with manifest property `router_configurer.tcp_stats_collection_interval`
 
 
  [Top](#top)


### PR DESCRIPTION
This PR modifies routing metric descriptions with the correct frequency each metric is emitted through the firehose.

https://www.pivotaltracker.com/story/show/123528571

@flawedmatrix && @crhino 