### PR TITLE
Removes unused metrics

### DIFF
--- a/metrics/_doppler.html.md.erb
+++ b/metrics/_doppler.html.md.erb
@@ -9,9 +9,7 @@ Metric Name                                                 | Description
  dropsondeUnmarshaller.counterEventReceived                 | Lifetime number of CounterEvent messages unmarshalled
  dropsondeUnmarshaller.errorReceived                        | Lifetime number of Error messages unmarshalled
  dropsondeUnmarshaller.heartbeatReceived                    | DEPRECATED
- dropsondeUnmarshaller.httpStartReceived                    | Lifetime number of HttpStart messages unmarshalled
  dropsondeUnmarshaller.httpStartStopReceived                | Lifetime number of HttpStartStop messages unmarshalled
- dropsondeUnmarshaller.httpStopReceived                     | Lifetime number of HttpStop messages unmarshalled
  dropsondeUnmarshaller.logMessageTotal                      | Lifetime number of LogMessage messages unmarshalled
  dropsondeUnmarshaller.unmarshalErrors                      | Lifetime number of errors when unmarshalling messages
  dropsondeUnmarshaller.valueMetricReceived                  | Lifetime number of ValueMetric messages unmarshalled

--- a/metrics/_metron_agent.html.md.erb
+++ b/metrics/_metron_agent.html.md.erb
@@ -3,12 +3,6 @@ Default Origin Name: MetronAgent
 Metric Name                                    | Description
 -----------------------------------------------|----------------------------------------------------------------------------------------------------------------
  MessageAggregator.counterEventReceived        | Lifetime number of CounterEvents aggregated in Metron
- MessageAggregator.httpStartReceived           | Lifetime number of HTTPStart aggregated in Metron
- MessageAggregator.httpStartStopEmitted        | Lifetime number of HTTPStartStop events emitted by Metron (created by combining HTTPStart and HTTPStop events)
- MessageAggregator.httpStopReceived            | Lifetime number of HTTPStop aggregated in Metron
- MessageAggregator.httpUnmatchedStartReceived  | Lifetime number of HTTPStart events for which no HTTPStop was received
- MessageAggregator.httpUnmatchedStopReceived   | Lifetime number of HTTPStop events for which no HTTPStart was received
- MessageAggregator.uncategorizedEvents         | Lifetime number of non-(CounterEvent  HTTPStart HTTPStop) events processed by aggregator
  MessageBuffer.droppedMessageCount             | Lifetime number of intentionally dropped messages from Metron's batch writer buffer. Batch writing is performed over TCP/TLS only.
  DopplerForwarder.sentMessages                 | Lifetime number of messages sent to Doppler regardless of protocol. Emitted every 30 seconds
  dropsondeAgentListener.currentBufferCount     | Instantaneous number of Dropsonde messages read by UDP socket  but not yet unmarshalled
@@ -18,9 +12,7 @@ Metric Name                                    | Description
  dropsondeMarshaller.counterEventMarshalled    | Lifetime number of CounterEvent messages marshalled
  dropsondeMarshaller.errorMarshalled           | Lifetime number of Error messages marshalled
  dropsondeMarshaller.heartbeatMarshalled       | Lifetime number of Heartbeat messages marshalled
- dropsondeMarshaller.httpStartMarshalled       | Lifetime number of HttpStart messages marshalled
  dropsondeMarshaller.httpStartStopMarshalled   | Lifetime number of HttpStartStop messages marshalled
- dropsondeMarshaller.httpStopMarshalled        | Lifetime number of HttpStop messages marshalled
  dropsondeMarshaller.logMessageMarshalled      | Lifetime number of LogMessage messages marshalled
  dropsondeMarshaller.marshalErrors             | Lifetime number of errors when marshalling messages
  dropsondeMarshaller.valueMetricMarshalled     | Lifetime number of ValueMetric messages marshalled
@@ -28,9 +20,7 @@ Metric Name                                    | Description
  dropsondeUnmarshaller.counterEventReceived    | Lifetime number of CounterEvent messages unmarshalled
  dropsondeUnmarshaller.errorReceived           | Lifetime number of Error messages unmarshalled
  dropsondeUnmarshaller.heartbeatReceived       | DEPRECATED
- dropsondeUnmarshaller.httpStartReceived       | Lifetime number of HttpStart messages unmarshalled
  dropsondeUnmarshaller.httpStartStopReceived   | Lifetime number of HttpStartStop messages unmarshalled
- dropsondeUnmarshaller.httpStopReceived        | Lifetime number of HttpStop messages unmarshalled
  dropsondeUnmarshaller.logMessageTotal         | Lifetime number of LogMessage messages unmarshalled
  dropsondeUnmarshaller.unmarshalErrors         | Lifetime number of errors when unmarshalling messages
  dropsondeUnmarshaller.valueMetricReceived     | Lifetime number of ValueMetric messages unmarshalled


### PR DESCRIPTION
The HttpStart and HttpStop envelope types have been unused and deprecated in loggregator
for a very long time.  We haven't been emitting them for quite a while, and we're not
even using them internally since November, 2015.  We're starting to remove all related
code, so it makes sense to drop them from the docs, as well.

In the process of dropping that code, we also removed the `MessageAggregator.uncategorizedEvents` because it seems mostly useless.  It'll just be a duplicate of metron's total sent messages minus `MessageAggregator.counterEventReceived`, since the `MessageAggregator` no longer does anything with `HttpStart` and `HttpStop` events.

[#126660411]

Signed-off-by: Sam Nelson <snelson@pivotal.io>