### PR TITLE
Update the description for total_routes metric

### DIFF
--- a/metrics/_routing.html.md.erb
+++ b/metrics/_routing.html.md.erb
@@ -35,7 +35,7 @@ Routing Release metrics have following origin names:
  routed\_app\_requests              | The collector sums up requests for all dea-{index} components for its output metrics. Emitted every 5 seconds.
  total\_requests                    | Lifetime number of requests received. Emitted every 5 seconds.
  ms\_since\_last\_registry\_update  | Time in millisecond since the last route register has been been received. Emitted every 30 seconds.
- total\_routes                      | Lifetime number of routes registered. Emitted every 30 seconds.
+ total\_routes                      | Current number of routes registered. Emitted every 30 seconds.
  uptime                             | Uptime for router. Emitted every second.
 
 <a id="routing_api"></a>Default Origin Name: routing_api


### PR DESCRIPTION
`total_routes` metric represents the current number of registered routes and
not lifetime number.

Track story: https://www.pivotaltracker.com/story/show/131559337

Regards
Shash && Swetha
CF Routing team