### PR TITLE
Remove deprecated tag

### DIFF
--- a/log-ops-guide.html.md.erb
+++ b/log-ops-guide.html.md.erb
@@ -47,7 +47,7 @@ Doppler resources can require scaling to accommodate your overall log and metric
 
 Because it can be challenging to understand the ratio of metrics to logs, Cloud Foundry also recommends monitoring and scaling Doppler based on its ingress traffic. To do this, you need to sum two metrics and rate them per second:
 
-<p class="tip"><em>Number of Doppler instances = <code>doppler.ingress</code> + <code>DopplerServer.listeners.receivedEnvelopes</code> / 10,000</em></p>
+<p class="tip"><em>Number of Doppler instances = <code>doppler.ingress</code> / 16,000</em></p>
 
 Using maximum values over a two-week period is a recommended approach for ingress-based capacity planning.
 


### PR DESCRIPTION
- `DopplerServer.listeners.receivedEnvelopes` no longer exists
- `doppler.ingress` is the same as "Number of envelopes"

[#165744546]