### PR TITLE
Diego container metrics are by default emitted every 15 s

### DIFF
--- a/container-metrics.html.md.erb
+++ b/container-metrics.html.md.erb
@@ -9,7 +9,7 @@ App metrics include the container metrics described below, plus any custom app m
 
 ## <a id="container-metrics"></a> Diego Container Metrics
 
-Diego containers emit the following resource usage metrics for their app instance (AI).  Each metric is averaged over and emitted every 60 seconds.
+Diego containers emit the following resource usage metrics for their app instance (AI).  Each metric is averaged over and emitted every 15 seconds.
 
 | Metric | Description | Unit |
 |---|---|---|


### PR DESCRIPTION
Source:
https://github.com/cloudfoundry/diego-release/blob/develop/jobs/rep/spec#L137-L139