### PR TITLE
Change how log line limits drop lines

### DIFF
--- a/app-log-rate-limits.html.md.erb
+++ b/app-log-rate-limits.html.md.erb
@@ -19,7 +19,7 @@ This topic describes app log rate limiting for apps in <%= vars.app_runtime_full
 In <%= vars.app_runtime_abbr %>, you can limit the number of log lines each app instance can
 generate per second by configuring <%= vars.app_rate_log_limit_config %>.
 
-App log rate limiting is disabled by default. <%= vars.company_name %> recomends enabling this feature to prevent app instances
+App log rate limiting is disabled by default. <%= vars.company_name %> recommends enabling this feature to prevent app instances
 from overloading the Loggregator Agent with logs, so the Loggregator Agent does not drop logs
 for other app instances on the same Diego Cell. Enabling this feature can also prevent apps from
 reporting inaccurate app metrics in the Cloud Foundry Command Line Interface (cf CLI) which can happen
@@ -49,7 +49,7 @@ the rate limit.
 
 When an app instance exceeds the configured rate limit, Diego will drop the app logs which exceed
 the per-second rate you configured through <%= vars.app_rate_log_limit_config %>. 
-When this happens, there will be a message indiciating that logs are being dropped.
+When this happens, there will be a message indicating that logs are being dropped.
 
 For more information about how Diego rate limits app logs, see
 [package rate](https://godoc.org/golang.org/x/time/rate) in the Go documentation.

--- a/app-log-rate-limits.html.md.erb
+++ b/app-log-rate-limits.html.md.erb
@@ -3,6 +3,12 @@ title: App Log Rate Limiting
 owner: Logging and Metrics
 ---
 
+<p class="note warning"><strong>Warning:</strong> 
+Previously, Diego was placing logs into a buffer and releasing them in accordance with the log line limit that was set. 
+If the buffer overflowed, logs would be dropped. The new behavior is to immediately output logs without placing them into a buffer. 
+When the limit is reached, logs are dropped. This change makes the timestamps of logs match when they were actually output by the app.
+</p>
+
 This topic describes app log rate limiting for apps in <%= vars.app_runtime_full %>
 (<%= vars.app_runtime_abbr %>).
 
@@ -28,7 +34,7 @@ limit the CPU usage of logging agents on the Diego Cell VM.
 
 The ideal app logging rate for a deployment depends on characteristics such as VM sizes and
 the number and type of apps in <%= vars.app_runtime_abbr %>. <%= vars.company_name %> recommends
-using at minimum the default limit of `100` as otherwise logs can be substantially delayed given the buffer size.
+using at minimum the default limit of `100` lines/second.
 
 
 When you enable app log rate limiting, Diego applies the rate limit to each app instance. For
@@ -40,12 +46,9 @@ the rate limit.
 
 ## <a id='exceed-limit'></a> What Happens When App Instances Exceed the App Log Rate Limit
 
-When an app instance exceeds the configured rate limit, Diego stores the app logs in a buffer
-and releases them into the logging stream at the per-second rate you configure through
-<%= vars.app_rate_log_limit_config %>. This buffer holds approximately 5Mb to 10Mb of logs. If an app's
-logs exceed the size of the buffer the log lines will be dropped before being forwarded off the Diego
-Cell. While there are app logs in the buffer a message indiciating the app is exceeding the rate limit
-will appear in the app log stream once per second.
+When an app instance exceeds the configured rate limit, Diego will drop the app logs which exceed
+the per-second rate you configured through <%= vars.app_rate_log_limit_config %>. 
+When this happens, there will be a message indiciating that logs are being dropped.
 
 For more information about how Diego rate limits app logs, see
 [package rate](https://godoc.org/golang.org/x/time/rate) in the Go documentation.

--- a/app-log-rate-limits.html.md.erb
+++ b/app-log-rate-limits.html.md.erb
@@ -5,8 +5,9 @@ owner: Logging and Metrics
 
 <p class="note warning"><strong>Warning:</strong> 
 Previously, Diego was placing logs into a buffer and releasing them in accordance with the log line limit that was set. 
-If the buffer overflowed, logs would be dropped. The new behavior is to immediately output logs without placing them into a buffer. 
-When the limit is reached, logs are dropped. This change makes the timestamps of logs match when they were actually output by the app.
+If the limit is exceed, logs would be delayed. If the buffer overflowed, logs would be dropped. The new behavior is to 
+immediately output logs without placing them into a buffer. When the limit is reached, logs are dropped. This change makes 
+the timestamps of logs match when they were actually output by the app.
 </p>
 
 This topic describes app log rate limiting for apps in <%= vars.app_runtime_full %>


### PR DESCRIPTION
This PR is to update the docs to reflect new behavior for the beta log-rate-limit feature.

Previously, Diego was placing logs into a buffer and releasing them in accordance with the log line limit that was set. 
If the limit is exceeded, logs would be delayed. If the buffer overflowed, logs would be dropped. The new behavior is to immediately output logs without placing them into a buffer.  When the limit is reached, logs are dropped. This change makes the timestamps of logs match when they were actually output by the app.