### PR TITLE
Change log rate limit feature to bytes/second

### DIFF
--- a/app-log-rate-limits.html.md.erb
+++ b/app-log-rate-limits.html.md.erb
@@ -3,6 +3,12 @@ title: App Log Rate Limiting
 owner: Logging and Metrics
 ---
 
+<p class="note warning"><strong>Warning:</strong> 
+Previously, Diego was placing logs into a buffer and releasing them in accordance with the log line limit that was set. 
+If the buffer overflowed, logs would be dropped. The new behavior is to immediately output logs without placing them into a buffer. 
+When the limit is reached, logs are dropped. This change makes the timestamps of logs match when they were actually output by the app.
+</p>
+
 This topic describes app log rate limiting for apps in <%= vars.app_runtime_full %>
 (<%= vars.app_runtime_abbr %>).
 
@@ -28,7 +34,7 @@ limit the CPU usage of logging agents on the Diego Cell VM.
 
 The ideal app logging rate for a deployment depends on characteristics such as VM sizes and
 the number and type of apps in <%= vars.app_runtime_abbr %>. <%= vars.company_name %> recommends
-using at minimum the default limit of `100` as otherwise logs can be substantially delayed given the buffer size.
+using at minimum the default limit of `100` lines/second.
 
 
 When you enable app log rate limiting, Diego applies the rate limit to each app instance. For
@@ -40,12 +46,9 @@ the rate limit.
 
 ## <a id='exceed-limit'></a> What Happens When App Instances Exceed the App Log Rate Limit
 
-When an app instance exceeds the configured rate limit, Diego stores the app logs in a buffer
-and releases them into the logging stream at the per-second rate you configure through
-<%= vars.app_rate_log_limit_config %>. This buffer holds approximately 5Mb to 10Mb of logs. If an app's
-logs exceed the size of the buffer the log lines will be dropped before being forwarded off the Diego
-Cell. While there are app logs in the buffer a message indiciating the app is exceeding the rate limit
-will appear in the app log stream once per second.
+When an app instance exceeds the configured rate limit, Diego will drop the app logs which exceed
+the per-second rate you configured through <%= vars.app_rate_log_limit_config %>. 
+When this happens, there will be a message indiciating that logs are being dropped.
 
 For more information about how Diego rate limits app logs, see
 [package rate](https://godoc.org/golang.org/x/time/rate) in the Go documentation.

--- a/app-log-rate-limits.html.md.erb
+++ b/app-log-rate-limits.html.md.erb
@@ -4,7 +4,7 @@ owner: Logging and Metrics
 ---
 
 <p class="note"><strong>Note:</strong>
-The beta feature for log rate limits in lines/second, has been removed in favor of log rate limits in bytes/second.
+The beta feature for log rate limits in lines/second, has been deprecated in favor of log rate limits in bytes/second.
 </p>
 
 This topic describes app log rate limiting for apps in <%= vars.app_runtime_full %>
@@ -16,7 +16,7 @@ This topic describes app log rate limiting for apps in <%= vars.app_runtime_full
 In <%= vars.app_runtime_abbr %>, you can limit the number of bytes each app instance can
 generate per second by configuring <%= vars.app_rate_log_limit_config %>.
 
-App log rate limiting is disabled by default. <%= vars.company_name %> recomends enabling this feature to prevent app instances
+App log rate limiting is disabled by default. <%= vars.company_name %> recommends enabling this feature to prevent app instances
 from overloading the Loggregator Agent with logs, so the Loggregator Agent does not drop logs
 for other app instances on the same Diego Cell. Enabling this feature can also prevent apps from
 reporting inaccurate app metrics in the Cloud Foundry Command Line Interface (cf CLI) which can happen
@@ -45,7 +45,7 @@ the rate limit.
 
 When an app instance exceeds the configured rate limit, Diego will drop the app logs which exceed
 the per-second rate you configured through <%= vars.app_rate_log_limit_config %>. 
-When this happens, there will be a message indiciating that logs are being dropped.
+When this happens, there will be a message indicating that logs are being dropped.
 
 For more information about how Diego rate limits app logs, see
 [package rate](https://godoc.org/golang.org/x/time/rate) in the Go documentation.

--- a/app-log-rate-limits.html.md.erb
+++ b/app-log-rate-limits.html.md.erb
@@ -3,10 +3,8 @@ title: App Log Rate Limiting
 owner: Logging and Metrics
 ---
 
-<p class="note warning"><strong>Warning:</strong> 
-Previously, Diego was placing logs into a buffer and releasing them in accordance with the log line limit that was set. 
-If the buffer overflowed, logs would be dropped. The new behavior is to immediately output logs without placing them into a buffer. 
-When the limit is reached, logs are dropped. This change makes the timestamps of logs match when they were actually output by the app.
+<p class="note"><strong>Note:</strong>
+The beta feature for log rate limits in lines/second, has been removed in favor of log rate limits in bytes/second.
 </p>
 
 This topic describes app log rate limiting for apps in <%= vars.app_runtime_full %>
@@ -15,7 +13,7 @@ This topic describes app log rate limiting for apps in <%= vars.app_runtime_full
 
 ## <a id='overview'></a> Overview of App Log Rate Limiting
 
-In <%= vars.app_runtime_abbr %>, you can limit the number of log lines each app instance can
+In <%= vars.app_runtime_abbr %>, you can limit the number of bytes each app instance can
 generate per second by configuring <%= vars.app_rate_log_limit_config %>.
 
 App log rate limiting is disabled by default. <%= vars.company_name %> recomends enabling this feature to prevent app instances
@@ -34,8 +32,7 @@ limit the CPU usage of logging agents on the Diego Cell VM.
 
 The ideal app logging rate for a deployment depends on characteristics such as VM sizes and
 the number and type of apps in <%= vars.app_runtime_abbr %>. <%= vars.company_name %> recommends
-using at minimum the default limit of `100` lines/second.
-
+using at minimum the default limit of `1k` bytes/second.
 
 When you enable app log rate limiting, Diego applies the rate limit to each app instance. For
 example, if there are five instances of an app running, Diego does not sum the logging rates
@@ -107,7 +104,7 @@ Diego also logs when a noisy app instance exceeds the rate limit set in <%= vars
 A log message similar to the example below appears in the log stream for the noisy app:
 
 <pre class="terminal">
-2020-02-24T12:42:18.90-0800 [APP/PROC/WEB/0] OUT app instance exceeded log rate limit (100 log-lines/sec) set by platform operator
+2022-08-22T12:42:18.90-0800 [APP/PROC/WEB/0] OUT app instance exceeded log rate limit (1024 bytes/sec)
 </pre>
 
 To identify which app instances are exceeding the app log rate limit:
@@ -136,7 +133,7 @@ To identify which app instances are exceeding the app log rate limit:
     limit"`, similar to the following example:
 
     <pre class="terminal">
-    origin:"rep" eventType:LogMessage timestamp:1583859621886751670 deployment:"warp-drive" job:"diego-cell" index:"3a574bde-91df-48b8-ae21-1d6913da0908" ip:"10.0.1.33" tags:&#60;key:"app_id" value:"34bcfafc-402b-4bb4-84db-aea5401b79eb" > tags:&#60;key:"app_name" value:"app-2" > tags:&#60;key:"instance_id" value:"0" > tags:&#60;key:"organization_id" value:"a30f39c2-4ff3-48a1-a869-a9ed21812a61" > tags:&#60;key:"organization_name" value:"test" > tags:&#60;key:"process_id" value:"34bcfafc-402b-4bb4-84db-aea5401b79eb" > tags:&#60;key:"process_instance_id" value:"92e2ee78-3a1d-41a6-4933-e47b" > tags:&#60;key:"process_type" value:"web" > tags:&#60;key:"source_id" value:"34bcfafc-402b-4bb4-84db-aea5401b79eb" > tags:&#60;key:"space_id" value:"0e2d2d58-3ef5-43f3-b880-c8a30903a96b" > tags:&#60;key:"space_name" value:"test-2" > logMessage:&#60;message:"app instance exceeded log rate limit (100 log-lines/sec) set by platform operator" message_type:OUT timestamp:1583859621886751670 app_id:"34bcfafc-402b-4bb4-84db-aea5401b79eb" source_type:"APP/PROC/WEB" source_instance:"0" >
+    origin:"rep" eventType:LogMessage timestamp:1583859621886751670 deployment:"warp-drive" job:"diego-cell" index:"3a574bde-91df-48b8-ae21-1d6913da0908" ip:"10.0.1.33" tags:&#60;key:"app_id" value:"34bcfafc-402b-4bb4-84db-aea5401b79eb" > tags:&#60;key:"app_name" value:"app-2" > tags:&#60;key:"instance_id" value:"0" > tags:&#60;key:"organization_id" value:"a30f39c2-4ff3-48a1-a869-a9ed21812a61" > tags:&#60;key:"organization_name" value:"test" > tags:&#60;key:"process_id" value:"34bcfafc-402b-4bb4-84db-aea5401b79eb" > tags:&#60;key:"process_instance_id" value:"92e2ee78-3a1d-41a6-4933-e47b" > tags:&#60;key:"process_type" value:"web" > tags:&#60;key:"source_id" value:"34bcfafc-402b-4bb4-84db-aea5401b79eb" > tags:&#60;key:"space_id" value:"0e2d2d58-3ef5-43f3-b880-c8a30903a96b" > tags:&#60;key:"space_name" value:"test-2" > logMessage:&#60;message:"app instance exceeded log rate limit (1024 bytes/sec)" message_type:OUT timestamp:1583859621886751670 app_id:"34bcfafc-402b-4bb4-84db-aea5401b79eb" source_type:"APP/PROC/WEB" source_instance:"0" >
     </pre>
     You can inspect these logs to identify the app instances that are exceeding the app log
     rate limit.

--- a/app-log-rate-limits.html.md.erb
+++ b/app-log-rate-limits.html.md.erb
@@ -13,8 +13,7 @@ This topic describes app log rate limiting for apps in <%= vars.app_runtime_full
 
 ## <a id='overview'></a> Overview of App Log Rate Limiting
 
-In <%= vars.app_runtime_abbr %>, you can limit the number of bytes each app instance can
-generate per second by configuring <%= vars.app_rate_log_limit_config %>.
+Log rate limits are a feature that limits the number of logs that can be sent to an app.
 
 App log rate limiting is disabled by default. <%= vars.company_name %> recommends enabling this feature to prevent app instances
 from overloading the Loggregator Agent with logs, so the Loggregator Agent does not drop logs
@@ -22,6 +21,26 @@ for other app instances on the same Diego Cell. Enabling this feature can also p
 reporting inaccurate app metrics in the Cloud Foundry Command Line Interface (cf CLI) which can happen
 if Log Cache evicts metrics from the cache in order to store large volumes of logs. It also can
 limit the CPU usage of logging agents on the Diego Cell VM.
+
+Log rate limits can be enabled on a per-app basis in bytes/second (preferred) or globally in lines/second (deprecated).
+
+### <a id='overview-byte-limit'></a> App Log Rate Limiting in Bytes/Second
+
+In <%= vars.app_runtime_abbr %>, you can limit the number of bytes each app instance can
+generate per second.
+
+This setting can be specified on a per-app basis in the application manifest or using the CLI.
+In addition, the log rate limit can be enforced on an org or space level using quota plans,
+see [Creating and Modifying Quota Plans](../adminguide/quota-plans.html).
+
+### <a id='overview-line-limit'></a> Deprecated: Global Log Rate Limiting in Lines/Second
+
+This feature has been deprecated in favor of log rate limits in bytes/second.
+<%= vars.company_name %> recommends migrating to log rate limits in bytes/second.
+
+In <%= vars.app_runtime_abbr %>, you can limit the number of log lines each app instance can
+generate per second by configuring <%= vars.app_rate_log_limit_config %>. This is a global setting that
+will apply to all applications.
 
 <% if not vars.platform_code == "CF" %>
 <%= vars.app_rate_log_limit_config_procedure %>
@@ -57,7 +76,7 @@ The Diego Cell containing the app instance emits the `AppInstanceExceededLogRate
 counter metric when it exceeds the rate limit, similar to the following example:
 
 <pre class="terminal">
-origin:"rep" eventType:CounterEvent timestamp:1582582740243576212 deployment:"cf" job:"diego-cell" index:"0e98fd00-47b2-4589-94f0-385f78b3a04d" ip:"10.0.1.12" tags:&#60;key:"instance_id" value:"0e98fd00-47b2-4589-94f0-385f78b3a04d" > tags:&#60;key:"source_id" value:"rep" > counterEvent:&#60;name:"AppInstanceExceededLogRateLimitCount" delta:1 total:206 >
+origin:"rep" eventType:CounterEvent timestamp:1582582740243576212 deployment:"cf" job:"diego-cell" index:"0e98fd00-47b2-4589-94f0-385f78b3a04d" ip:"10.0.1.12" tags:<key:"instance_id" value:"0e98fd00-47b2-4589-94f0-385f78b3a04d" > tags:<key:"source_id" value:"rep" > counterEvent:<name:"AppInstanceExceededLogRateLimitCount" delta:1 total:206 >
 </pre>
 
 Each Diego Cell in a deployment has a unique `AppInstanceExceededLogRateLimitCount` counter.

--- a/container-metrics.html.md.erb
+++ b/container-metrics.html.md.erb
@@ -19,51 +19,51 @@ The following table describes all Diego container metrics:
     <th width=65%>Description</th>
     <th width=15%>Unit</th>
   </tr><tr>
-    <td><code>CpuPercentage</code></td>
+    <td><code>cpu</code></td>
     <td>CPU time used by AI as a percentage of a single CPU core.<br><br>
     This is usually no greater than <code>100% * the number of vCPUs on the host Diego cell</code>, but it may be more due to discrepancies in measurement timing.</td>
     <td><code>float64</code></td>
   </tr><tr>
-    <td><code>AbsoluteCPUEntitlement</code></td>
+    <td><code>absolute_entitlement</code></td>
     <td>CPU time that the AI was entitled to use.<br><br>
     At minimum, the CPU time that a Diego cell provides an AI is <code>min(app memory, 8 GB) * (Diego cell vCPUs/Diego cell memory) * 100%</code>.<br><br>
     The platform operator can provide the Diego cell <code>vCPUs/memory</code> ratio to developers.<br>
     If a Diego cell is not at capacity or if other workloads on it are idle, the cell can provide more than the minimum CPU.</td>
-    <td><code>uint64</code></td>
+    <td><code>float64</code></td>
   </tr><tr>
-    <td><code>AbsoluteCPUUsage</code></td>
+    <td><code>absolute_usage</code></td>
     <td>CPU time used by AI.<br><br>
-    <code>AbsoluteCPUUsage / AbsoluteCPUEntitlement</code> calculates a 0-100% range of AI usage per entitlement.</td>
+    <code>absolute_usage / absolute_entitlement</code> calculates a 0-100% range of AI usage per entitlement.</td>
+    <td><code>float64</code></td>
+  </tr><tr>
+    <td><code>memory</code></td>
+    <td>RAM memory used by AI, in bytes.</td>
     <td><code>uint64</code></td>
   </tr><tr>
-    <td><code>MemoryBytes</code></td>
-    <td>RAM memory used by AI, in MB.</td>
-    <td><code>uint64</code></td>
+    <td><code>memory_quota</code></td>
+    <td>RAM memory available, in bytes.</td>
+    <td><code>float64</code></td>
   </tr><tr>
-    <td><code>MemoryBytesQuota</code></td>
-    <td>RAM memory available, in GB.</td>
-    <td><code>uint64</code></td>
+    <td><code>disk</code></td>
+    <td>Disk space used by AI, in bytes.</td>
+    <td><code>float64</code></td>
   </tr><tr>
-    <td><code>DiskBytes</code></td>
-    <td>Disk space used by AI, in MB.</td>
-    <td><code>uint64</code></td>
+    <td><code>disk_quota</code></td>
+    <td>Disk space available, in bytes.</td>
+    <td><code>float64</code></td>
   </tr><tr>
-    <td><code>DiskBytesQuota</code></td>
-    <td>Disk space available, in GB.</td>
-    <td><code>uint64</code></td>
-  </tr><tr>
-    <td><code>ContainerAge</code></td>
+    <td><code>container_age</code></td>
     <td>Age of container, in nanoseconds.</td>
-    <td><code>uint64</code></td>
+    <td><code>float64</code></td>
   </tr>
 </table>
 
 **Loggregator v1**: Most of the container metrics are emitted in a `ContainerMetric` envelope.
-The `AbsoluteCPUEntitlement`, `AbsoluteCPUUsage`, and `ContainerAge` container metrics are emitted
+The `absolute_entitlement`, `absolute_usage`, and `container_age` container metrics are emitted
 as separate `ValueMetric` envelopes.
 
 **Loggregator v2**: All container metrics are emitted in gauge envelopes. The
-`AbsoluteCPUEntitlement`, `AbsoluteCPUUsage`, and `ContainerAge` container metrics are emitted in a
+`absolute_entitlement`, `absolute_usage`, and `container_age` container metrics are emitted in a
 separate envelope to the other container metrics.
 
 ## <a id="cf-cli"></a> Retrieve Container Metrics from the cf CLI
@@ -80,9 +80,9 @@ The command output lists Diego container metric values as follows:
 
 | Label in Output | Metrics listed, as described in [Diego Container Metrics](#container-metrics), above |
 |---|---|
-| `cpu` | `CpuPercentage` |
-| `memory` | `MemoryBytes` of `MemoryBytesQuota` |
-| `disk` | `DiskBytes` of `DiskBytesQuota` |
+| `cpu` | `cpu` |
+| `memory` | `memory` of `memory_quota` |
+| `disk` | `disk` of `disk_quota` |
 
 For example:
 
@@ -106,7 +106,7 @@ memory usage:   256M
 
 ### <a id="cf-app"></a> Retrieve CPU Entitlement Metrics (Experimental)
 
-To see app instance `AbsoluteCPUEntitlement` metrics from the command line:
+To see app instance `absolute_entitlement` metrics from the command line:
 
 1. Install the CPU Entitlement Plugin from [cpu-entitlement-plugin](https://github.com/cloudfoundry/cpu-entitlement-plugin) in GitHub.
 

--- a/container-metrics.html.md.erb
+++ b/container-metrics.html.md.erb
@@ -55,16 +55,25 @@ The following table describes all Diego container metrics:
     <td><code>container_age</code></td>
     <td>Age of container, in nanoseconds.</td>
     <td><code>float64</code></td>
+  </tr><tr>
+    <td><code>log_rate</code></td>
+    <td>Log rate used by AI, in bytes per second.</td>
+    <td><code>float64</code></td>
+  </tr><tr>
+    <td><code>log_rate_limit</code></td>
+    <td>Log rate available, in bytes per second.</td>
+    <td><code>float64</code></td>
   </tr>
+
 </table>
 
 **Loggregator v1**: Most of the container metrics are emitted in a `ContainerMetric` envelope.
-The `absolute_entitlement`, `absolute_usage`, and `container_age` container metrics are emitted
-as separate `ValueMetric` envelopes.
+The `absolute_entitlement`, `absolute_usage`, `container_age`, `log_rate` and `log_rate_limit`
+container metrics are emitted as separate `ValueMetric` envelopes.
 
 **Loggregator v2**: All container metrics are emitted in gauge envelopes. The
-`absolute_entitlement`, `absolute_usage`, and `container_age` container metrics are emitted in a
-separate envelope to the other container metrics.
+`absolute_entitlement`, `absolute_usage`, `container_age`, `log_rate` and `log_rate_limit`
+container metrics are emitted in separate envelopes to the other container metrics.
 
 ## <a id="cf-cli"></a> Retrieve Container Metrics from the cf CLI
 
@@ -92,16 +101,19 @@ Showing health and status for app dora-example in org o / space s as admin...
 
 name:              dora-example
 requested state:   started
-routes:            dora-example.bosh-lite.com
-last uploaded:     Fri 05 Apr 10:41:21 PDT 2019
+routes:            dora-example.example.com
+last uploaded:     Fri 16 Sep 01:38:32 UTC 2022
 stack:             cflinuxfs3
-buildpacks:        ruby
+buildpacks:
+	name             version   detect output   buildpack name
+	ruby_buildpack   1.8.58    ruby            ruby
 
 type:           web
+sidecars:
 instances:      1/1
-memory usage:   256M
-     state     since                  cpu    memory          disk          details
-#0   running   2019-04-05T17:41:31Z   0.4%   39.5M of 256M   89.9M of 1G
+memory usage:   1024M
+     state     since                  cpu    memory        disk          logging            details
+#0   running   2022-09-16T01:38:46Z   0.2%   36.3M of 1G   90.3M of 1G   0/s of unlimited
 </pre>
 
 ### <a id="cf-app"></a> Retrieve CPU Entitlement Metrics (Experimental)


### PR DESCRIPTION
This PR is to update the docs to reflect the new feature replacing the beta log-rate-limit feature in lines to now be in bytes/second.

