### PR TITLE
Add container network metrics documentation

### DIFF
--- a/container-metrics.html.md.erb
+++ b/container-metrics.html.md.erb
@@ -76,6 +76,16 @@ The following table describes all Diego container metrics:
     <td>The log rate limit in bytes per second for an app instance.</td>
     <td><code>float64</code></td>
   </tr>
+  </tr><tr>
+    <td><code>rx_bytes</code></td>
+    <td>Received network traffic in bytes for an app instance.</td>
+    <td><code>float64</code></td>
+  </tr>
+  </tr><tr>
+    <td><code>tx_bytes</code></td>
+    <td>Transmitted network traffic in bytes for an app instance.</td>
+    <td><code>float64</code></td>
+  </tr>
 </table>
 
 The way that Diego emits container metrics differs depending on the version of Loggregator used in your <%= vars.app_runtime_abbr %> deployment:
@@ -83,10 +93,12 @@ The way that Diego emits container metrics differs depending on the version of L
 * **Loggregator v1:** Diego emits most container metrics in a `ContainerMetric` envelope. Diego emits the `absolute_entitlement`, `absolute_usage`,
 `container_age`, `log_rate`, and `log_rate_limit` container metrics in `ValueMetric` envelopes.
 
-* **Loggregator v2:** Diego emits all container metrics in gauge envelopes. Diego emits the `absolute_entitlement`, `absolute_usage`, `container_age`, `log_rate`, and `log_rate_limit` container metrics in separate gauge envelopes from other container metrics. The container metrics come in three envelopes:
+* **Loggregator v2:** Diego emits all container metrics in gauge and counter envelopes. Diego emits the `absolute_entitlement`, `absolute_usage`, `container_age`, `log_rate`, and `log_rate_limit` container metrics in separate gauge envelopes from other container metrics. The container metrics come in five envelopes:
     * One envelope containing `cpu`, `disk`, `disk_quota`, `memory`, and `memory_quota`
     * One envelope containing `absolute_entitlement`, `absolute_usage`, and `container_age`
     * One envelope containing `log_rate` and `log_rate_limit`
+    * One envelope containing `rx_bytes`
+    * One envelope containing `tx_bytes`
 
 
 ## <a id='cf-cli'></a> Retrieving container metrics from the cf CLI
@@ -96,6 +108,8 @@ You can retrieve container metrics using the Cloud Foundry Command Line Interfac
 * To retrieve CPU, memory, and disk metrics for all instances of an app, see [Retrieve CPU, memory, and disk metrics](#cpu-mem-disk).
 * To retrieve CPU entitlement metrics for all instances of an app, see [Retrieve CPU Entitlement metrics](#cpu-entitlement).
 * To determine when an app has exceeded its CPU entitlement, see [Monitor apps that exceed their CPU Entitlement](#cpu-entitlement).
+
+# TODO: Do we need an example here as well how to retrieve traffic metrics?
 
 ### <a id='cf-mem-disk'></a> Retrieving CPU, memory, and disk metrics
 

--- a/container-metrics.html.md.erb
+++ b/container-metrics.html.md.erb
@@ -108,8 +108,7 @@ You can retrieve container metrics using the Cloud Foundry Command Line Interfac
 * To retrieve CPU, memory, and disk metrics for all instances of an app, see [Retrieve CPU, memory, and disk metrics](#cpu-mem-disk).
 * To retrieve CPU entitlement metrics for all instances of an app, see [Retrieve CPU Entitlement metrics](#cpu-entitlement).
 * To determine when an app has exceeded its CPU entitlement, see [Monitor apps that exceed their CPU Entitlement](#cpu-entitlement).
-
-# TODO: Do we need an example here as well how to retrieve traffic metrics?
+* To retrieve network traffic metrics for all instances of an app, see [Retrieve network traffic metrics](#cf-network-traffic).
 
 ### <a id='cf-mem-disk'></a> Retrieving CPU, memory, and disk metrics
 
@@ -206,3 +205,25 @@ Plug-in](https://github.com/cloudfoundry/cpu-entitlement-plugin/releases) reposi
   </pre>
   The previous example output shows that the three listed apps have an average CPU usage that exceeds 100% of their entitlements. When an app's average CPU usage
   exceeds its CPU entitlement, consider increasing their CPU entitlement to ensure that they do not become throttled.
+
+### <a id='cf-network-traffic'></a> Retrieve network traffic metrics
+
+To retrieve received- and transmitted bytes for all instances of an app:
+
+1. Install the Log Cache CLI Plug-in from the [Log Cache cf CLI Plugin](https://github.com/cloudfoundry/log-cache-cli) repository on GitHub.
+
+1. In a terminal window, run:
+
+    ```
+    cf tail --name-filter="bytes" APP-NAME
+    ```
+    Where `APP-NAME` is the name of the app.
+    <br>
+    <br>
+    This command returns `rx_bytes` and `tx_bytes` metrics for all instances of the app, similar to the following example:
+    <pre class="terminal">
+    2023-08-10T13:27:50.27+0000 [my-app/0] COUNTER rx_bytes:24842
+    2023-08-10T13:27:50.27+0000 [my-app/0] COUNTER tx_bytes:24306
+    2023-08-10T13:27:50.27+0000 [my-app/1] COUNTER rx_bytes:14832
+    2023-08-10T13:27:50.27+0000 [my-app/1] COUNTER tx_bytes:32312
+    </pre>

--- a/container-metrics.html.md.erb
+++ b/container-metrics.html.md.erb
@@ -79,12 +79,12 @@ The following table describes all Diego container metrics:
   </tr><tr>
     <td><code>rx_bytes</code></td>
     <td>Received network traffic in bytes for an app instance.</td>
-    <td><code>float64</code></td>
+    <td><code>uint64</code></td>
   </tr>
   </tr><tr>
     <td><code>tx_bytes</code></td>
     <td>Transmitted network traffic in bytes for an app instance.</td>
-    <td><code>float64</code></td>
+    <td><code>uint64</code></td>
   </tr>
 </table>
 


### PR DESCRIPTION
With this release https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.38.0, CF is now able to emit container metrics for received- and transmitted bytes.

See also https://github.com/cloudfoundry/diego-logging-client/pull/82/files to see the new emitted metrics.

This PR adds documentation related to the new metrics which should be published to https://docs.cloudfoundry.org/loggregator/container-metrics.html.