### PR TITLE
Document envelope types

### DIFF
--- a/data-sources.html.md.erb
+++ b/data-sources.html.md.erb
@@ -259,3 +259,36 @@ and metrics:
 		</td>
 	</tr>
 </table>
+
+## <a id="envelopes"></a> Loggregator v2 envelope types
+
+#### Log
+
+A *Log* is used to represent a simple text payload.
+
+It represents whether the log is emitted to STDOUT or STDERR.
+
+#### Counter
+
+A *Counter* is used to represent a metric that only increases in value (*e.g.*
+`metron.sentEnvelopes`).
+
+The emitter of a counter must set the `delta` (anything else will be
+discarded). It also provides the sum of all emitted values.
+
+#### Gauge
+
+A *Gauge* is used to represent a metric that can have arbitary numeric values
+that increase or decrease.
+
+It can be used emit a set of relatable metrics (*e.g.* `memory{value=2048,
+unit=byte}, disk{value=4096, unit=byte}, cpu{value=2, unit=percentage}`)
+
+#### Timer
+
+A *Timer* is used to represent a metric that captures the duration of an
+event. (*e.g.* `databasePost`)
+
+#### Event
+
+An *Event* is used to represent data related to an asynchronous event that occured.

--- a/data-sources.html.md.erb
+++ b/data-sources.html.md.erb
@@ -172,7 +172,8 @@ product for viewing:
 * **Loggregator:** Loggregator is the transport system for both logs and metrics on apps deployed
 on <%= vars.app_runtime_abbr %>, as well as metrics on <%= vars.app_runtime_abbr %> platform
 components. For more information about the Loggregator system, including Loggregator architecture
-and components, see [Loggregator Architecture](architecture.html).
+and components, see [Loggregator Architecture](architecture.html). For more information on the types
+of envelopes being transported in loggregator, see [Envelope Types](https://github.com/cloudfoundry/loggregator-api#v2-envelope-types).
 
 * **rsyslogd on <%= vars.app_runtime_abbr %> component VMs:** rsyslogd is the transport system
 for <%= vars.app_runtime_abbr %> component logs. Users can configure rsyslogd to transport
@@ -259,36 +260,3 @@ and metrics:
 		</td>
 	</tr>
 </table>
-
-## <a id="envelopes"></a> Loggregator v2 envelope types
-
-#### Log
-
-A *Log* is used to represent a simple text payload.
-
-It represents whether the log is emitted to STDOUT or STDERR.
-
-#### Counter
-
-A *Counter* is used to represent a metric that only increases in value (*e.g.*
-`metron.sentEnvelopes`).
-
-The emitter of a counter must set the `delta` (anything else will be
-discarded). It also provides the sum of all emitted values.
-
-#### Gauge
-
-A *Gauge* is used to represent a metric that can have arbitary numeric values
-that increase or decrease.
-
-It can be used emit a set of relatable metrics (*e.g.* `memory{value=2048,
-unit=byte}, disk{value=4096, unit=byte}, cpu{value=2, unit=percentage}`)
-
-#### Timer
-
-A *Timer* is used to represent a metric that captures the duration of an
-event. (*e.g.* `databasePost`)
-
-#### Event
-
-An *Event* is used to represent data related to an asynchronous event that occured.


### PR DESCRIPTION
This documentation of envelope types exists already in the [loggregator-api README](https://github.com/cloudfoundry/loggregator-api#v2-envelope-types). Adding it to the main documentation to make it easier to find and clear up any confusion.