### PR TITLE
Document envelope types

### DIFF
--- a/data-sources.html.md.erb
+++ b/data-sources.html.md.erb
@@ -167,8 +167,11 @@ product for viewing:
 
 * **Loggregator:** Loggregator is the transport system for both logs and metrics on apps deployed
 on <%= vars.app_runtime_abbr %>, as well as metrics on <%= vars.app_runtime_abbr %> platform
-components. For more information about the Loggregator system, including Loggregator architecture
-and components, see [Loggregator Architecture](architecture.html).
+components.
+
+For more information about the Loggregator system, including Loggregator architecture
+and components, see [Loggregator Architecture](architecture.html) and for the types
+of envelopes being transported in Loggregator, see [Envelope Types](https://github.com/cloudfoundry/loggregator-api#v2-envelope-types).
 
 * **rsyslogd on <%= vars.app_runtime_abbr %> component VMs:** rsyslogd is the transport system
 for <%= vars.app_runtime_abbr %> component logs. Users can configure rsyslogd to transport


### PR DESCRIPTION
This documentation of envelope types exists already in the [loggregator-api README](https://github.com/cloudfoundry/loggregator-api#v2-envelope-types). Adding it to the main documentation to make it easier to find and clear up any confusion.