### PR TITLE
Remove reference to otel distribution config (5.0)

### DIFF
--- a/opentelemetry.html.md.erb
+++ b/opentelemetry.html.md.erb
@@ -90,11 +90,6 @@ the exporters that are available for use, run the following command on a VM that
 /var/vcap/packages/otel-collector/otel-collector components
 ```
 
-Alternatively, you can review the [distribution file](https://github.com/cloudfoundry/loggregator-agent-release/blob/main/src/otel-collector/config.yaml) used to build
-the <%= vars.app_runtime_abbr %> distribution of OTel Collector. Ensure that the tag of the
-loggregator-agent-release repository that you are reviewing matches the version of loggregator-agent-release that you
-plan to deploy.
-
 ## <a id='deploying'></a> Deploying the OpenTelemetry Collector
 
 <% if vars.platform_code == 'CF' %>


### PR DESCRIPTION
Asking the otel-collector binary directly which exporters are present is preferred to reviewing the distribution config.