### PR TITLE
Remove platform-conditional ERB blocks, keep OSS content [ai-assisted]

### DIFF
--- a/app-log-rate-limits.html.md.erb
+++ b/app-log-rate-limits.html.md.erb
@@ -26,7 +26,7 @@ In <%= vars.app_runtime_abbr %>, you can limit the number of bytes each app inst
 You can configure app log rate limiting in bytes per second on a per-app and per-task basis through the cf CLI. Log rate limits can also be
 defined for apps in the application manifest. Additionally, you can enforce the log rate limit you configure for all apps that are deployed
 within a space or org by specifying the log rate limit in the quota plan for the space or org.
-<% if vars.platform_code != "OFFLINE" %>For more information, see [Creating and Modifying Quota Plans](../adminguide/quota-plans.html).<% end %>
+For more information, see [Creating and Modifying Quota Plans](../adminguide/quota-plans.html).
 
 ## <a id='determine-limit'></a> Determining the ideal app log rate limit
 

--- a/data-sources.html.md.erb
+++ b/data-sources.html.md.erb
@@ -141,26 +141,12 @@ The following table describes the data included in logs and metrics from each so
   <td>
    <ul>
     <li>Container metrics<sup>3</sup></li>
-    <% if vars.platform_code != 'CF' %>
-    <li>Custom app metrics<sup>4</sup></li>
-    <% end %>
    </ul>
   </td>
  </tr>
 </table>
 
-<% if vars.platform_code == 'CF' || vars.platform_code == 'OFFLINE' %>
-
 <sup>2</sup>For more information about app logging, see [Streaming App Logs](/devguide/deploy-apps/streaming-logs.html).
-
-<% else %>
-
-<sup>1</sup>For more information about using the BOSH Health Monitor to collect health metrics
-on VMs, see [Configuring a Monitoring System](/operating/monitoring/metrics.html).
-
-<sup>2</sup>For more information about app logging, see [Streaming App Logs](/devguide/deploy-apps/streaming-logs.html).
-
-<% end %>
 
 <sup>3</sup>For more information about container metrics, see [Container Metrics](container-metrics.html).
 
@@ -230,9 +216,6 @@ and metrics:
           Firehose plug-in for CLI</a>.</li>
     <li>Loggregator Log Cache CLI plug-in. See <a href="https://plugins.cloudfoundry.org/">
           Cloud Foundry Community cf CLI plug-ins</a>.</li>
-    <% if vars.platform_code != 'CF' %>
-    <li><%= vars.platform_metric_tool_ref %></li>
-    <% end %>
    </ul>
   </td>
  </tr>
@@ -242,9 +225,6 @@ and metrics:
    You can use the following products or tools to view app logs:
    <ul>
     <li>cf CLI <code>cf logs</code> command.</a></li>
-    <% if vars.platform_code != 'CF' %>
-    <li><%= vars.manage_apps_service_instances_ref %></li>
-    <% end %>
     <li><%= vars.syslog_forwarding_ref %></li>
     <li>Loggregator Firehose CLI plug-in. See <a href="cli-plugin.html">Installing the Loggregator
           Firehose plug-in for CLI</a>.</li>
@@ -259,9 +239,6 @@ and metrics:
           Firehose plug-in for CLI</a>.</li>
     <li>Loggregator Log Cache CLI plug-in. See <a href="https://plugins.cloudfoundry.org/">
           Cloud Foundry Community cf CLI plug-ins</a>.</li>
-    <% if vars.platform_code != 'CF' %>
-    <li><%= vars.metrics_product_ref %></li>
-    <% end %>
    </ul>
   </td>
  </tr>

--- a/log-ops-guide.html.md.erb
+++ b/log-ops-guide.html.md.erb
@@ -3,13 +3,6 @@ title: Loggregator guide for Cloud Foundry operators
 owner: Logging and Metrics
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Loggregator Guide for", vars.app_runtime_abbr, "Operators") %>
-
-<% end %>
-
 Here you can view information for <%= vars.app_runtime_first %> deployment operators about how to configure the
 Loggregator system to avoid data loss with high volumes of logging and metrics data.
 
@@ -54,8 +47,6 @@ To measure the message reliability rate of your Loggregator system, you can run 
 
 ## <a id='scaling'></a> Scaling Loggregator
 
-<% if vars.platform_code == 'CF' %>
-
 Most Loggregator configurations are set to use preferred resource defaults. If you want to customize these defaults or plan the capacity of your Loggregator system, see the following formulas:
 
 ### <a id='doppler'></a> Doppler
@@ -89,12 +80,6 @@ logs and metrics are available at a time. <%= vars.recommended_by %> recommends 
 
 For more information about scaling the Loggregator system,
 see [Scaling Loggregator](../running/managing-cf/logging-config.html#scaling) in _Configuring System Logging_.
-
-<% else %>
-
-Most Loggregator configurations use preferred resource defaults. For more information about customizing these defaults and planning the capacity of your Loggregator system, see <%= vars.key_cap_link %>.
-
-<% end %>
 
 
 ## <a id='scaling-nozzles'></a> Scaling nozzles

--- a/opentelemetry.html.md.erb
+++ b/opentelemetry.html.md.erb
@@ -212,7 +212,6 @@ service:
 
 ## <a id='deploying'></a> Deploying the OpenTelemetry Collector
 
-<% if vars.platform_code == 'CF' %>
 CF Deployment provides [experimental operations files](https://github.com/cloudfoundry/cf-deployment/tree/main/operations/experimental)
 that you can use to deploy the OTel Collector:
 
@@ -227,6 +226,3 @@ bosh deploy cf-deployment.yml \
   --var-file=otel_collector_metric_exporters=YOUR_METRIC_EXPORTER_CONFIG_FILE_PATH.yml \
   --var=system_domain=YOUR_SYSTEM_DOMAIN
 ```
-<% else %>
-  <%= partial "/pcf/core/deploy_otel_collector" %>
-<% end %>


### PR DESCRIPTION
This repo is now dedicated to the OSS Cloud Foundry doc set, so the vars.platform_code conditionals (CF/PCF/OFFLINE branches) that used to support a shared commercial build no longer serve a purpose. Unwrap CF-branch content and drop else/PCF/OFFLINE branches accordingly.